### PR TITLE
Concat using puppetlabs instead of ripienaar repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/stackforge/puppet-cinder.git
 [submodule "concat"]
 	path = concat
-	url = https://github.com/ripienaar/puppet-concat.git
+	url = https://github.com/puppetlabs/puppet-concat.git
 [submodule "firewall"]
 	path = firewall
 	url = https://github.com/puppetlabs/puppetlabs-firewall.git


### PR DESCRIPTION
puppetlabs/puppet-concat is now the reference
ripienaar is an alias
commit version is unchanged
