### PR TITLE
Fixed firewalld package issue

### DIFF
--- a/firewall/manifests/linux/redhat.pp
+++ b/firewall/manifests/linux/redhat.pp
@@ -22,9 +22,10 @@ class firewall::linux::redhat (
   # lib/puppet/util/firewall.rb.
   if   ($::operatingsystem != 'Fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)
     or ($::operatingsystem == 'Fedora' and versioncmp($::operatingsystemrelease, '15') >= 0) {
-    package { 'firewalld':
-      ensure  => absent,
-      before  => Package['iptables-services'],
+    service { "firewalld":
+      ensure => stopped,
+      enable => false,
+      before => Package['iptables-services']
     }
 
     package { 'iptables-services':

--- a/firewall/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/firewall/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -12,7 +12,7 @@ describe 'firewall::linux::redhat', :type => :class do
           :operatingsystemrelease => osrel
         }}
 
-        it { should_not contain_package('firewalld') }
+        it { should_not contain_service('firewalld') }
         it { should_not contain_package('iptables-services') }
       end
     end
@@ -24,8 +24,9 @@ describe 'firewall::linux::redhat', :type => :class do
           :operatingsystemrelease => osrel
         }}
 
-        it { should contain_package('firewalld').with(
-          :ensure => 'absent',
+        it { should contain_service('firewalld').with(
+          :ensure => 'stopped',
+          :enable => false,
           :before => 'Package[iptables-services]'
         )}
 


### PR DESCRIPTION
Firewalld package cannot be uninstalled, because other packages might be dependent
on it. This patch makes just firewalld service to stop and be disabled.

For more info please check: https://bugzilla.redhat.com/show_bug.cgi?id=1148399
