### PR TITLE
Add Rakefile to run rspec tests over all the puppet modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+Gemfile.lock
+.vendor
+vendor
+*/spec/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+script: "bundle exec rake test SPEC_OPTS='--format documentation --color --backtrace'"
+rvm:
+  - 1.9.3
+  - 2.0.0
+matrix:
+  fast_finish: true
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,21 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+group :development, :test do
+  gem 'bundler'
+  gem 'r10k'
+  gem 'rake', '10.1.1'
+end
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+# vim:ft=ruby

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Openstack-Puppet-Modules (OPM)
+
+Puppet modules shared between packstack and foreman
+
+[![BuildStatus](https://api.travis-ci.org/redhat-openstack/openstack-puppet-modules.svg?branch=master)](https://travis-ci.org/redhat-openstack/openstack-puppet-modules)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,30 @@
+task(:default).clear
+task :default => :test
+
+desc 'Run Puppetfile Validation'
+task :test => [:validate_puppetfile,:all_modules]
+
+desc "Validate the Puppetfile syntax"
+task :validate_puppetfile do
+  $stderr.puts "---> syntax:puppetfile"
+  sh "r10k puppetfile check"
+end
+
+desc "Run rspec tests for each modules"
+task :all_modules do
+  FileList["*/Rakefile"].each do |project|
+    dir = project.pathmap("%d")
+    Dir.chdir(dir) do
+      puts "======"
+      puts "= Running spec test for #{project}"
+      puts "======"
+      system("rm -Rf vendor")
+      FileUtils.mkdir 'vendor'
+      ENV['GEM_HOME'] = './vendor'
+      system('bundle install')
+      system('bundle exec rake spec')
+      FileUtils.rmdir 'vendor'
+    end
+  end
+end
+


### PR DESCRIPTION
Added a Rakefile being able to run the rspec tests for each Puppet modules that OPM is managing !
Should be linked to Travis !

Signed-off-by: Gael Chamoulaud gchamoul@redhat.com
