### PR TITLE
Update puppet-ceilometer to latest master

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,7 @@ mod 'apache',
   :git => 'https://github.com/puppetlabs/puppetlabs-apache.git'
 
 mod 'ceilometer',
-  :commit => '1d78470e5023e2ca6adef47c904d14d046dd87d1',
+  :commit => '64d872cdef84867728087609996e5d9993398416',
   :git => 'https://github.com/stackforge/puppet-ceilometer.git'
 
 mod 'certmonger',

--- a/ceilometer/README.md
+++ b/ceilometer/README.md
@@ -1,7 +1,7 @@
 Ceilometer
 ==========
 
-4.0.0 - 2014.1.0 - Icehouse
+5.0.0 - 2014.2.0 - Juno
 
 #### Table of Contents
 
@@ -72,6 +72,37 @@ This is the ceilometer module.
 Release Notes
 -------------
 
+** 5.0.0 **
+* Stable Juno release
+* Added package_ensure parameters to various classes to control package installation
+* Added ceilometer::policy to control policy.json
+* Updated validate_re expressions for Puppet 3.7
+* Bumped stdlib dependency to >=4.0.0
+* Added manage_service parameters to various classes to control whether the service was managed, as well as added enabled parameters where not already present
+* Added parameters to control whether to configure keystone users
+* Added the ability to override the keystone service name in ceilometer::keystone::auth
+* Migrated the ceilometer::db::mysql class to use openstacklib::db::mysql and deprecated the mysql_module parameter
+* Fixed ceilometer-notification package name for RHEL
+* Removed deprecation notices for sectionless ceilometer_config types for Juno release
+* Added ability to hide secrets from puppet logs
+
+** 4.2.0 **
+
+* Fixed dependency on nova-common package
+* Added new class for extended logging options
+* Fixed ssl parameter requirements for kombu and rabbit
+* Fixed mysql_grant call
+* Fixed ceilometer-collecter service relationships when service is disabled
+
+
+** 4.1.0 **
+
+* Added RabbitMQ SSL Support.
+* Fixed dependency cycle bug.
+* Fixed agent_notification_service_name.
+* Changed default mysql charset to UTF8.
+* Pinned major gems.
+
 ** 4.0.0 **
 
 * Stable Icehouse release.
@@ -80,7 +111,6 @@ Release Notes
 * Fixed region name configuration.
 * Fixed ensure packages bug.
 * Added support for puppetlabs-mysql 2.2 and greater.
-* Fixed MySQL grant call.
 * Introduced ceilometer::config to handle additional custom options.
 
 ** 3.1.1 **

--- a/ceilometer/manifests/agent/central.pp
+++ b/ceilometer/manifests/agent/central.pp
@@ -13,11 +13,16 @@
 #    (optional) ensure state for package.
 #    Defaults to 'present'
 #
+#  [*coordination_url*]
+#    (optional) The url to use for distributed group membership coordination.
+#    Defaults to undef.
+#
 
 class ceilometer::agent::central (
   $manage_service   = true,
   $enabled          = true,
   $package_ensure   = 'present',
+  $coordination_url = undef,
 ) {
 
   include ceilometer::params
@@ -47,4 +52,8 @@ class ceilometer::agent::central (
     hasrestart => true,
   }
 
+  if $coordination_url {
+    ensure_resource('ceilometer_config', 'coordination/backend_url',
+      {'value' => $coordination_url})
+  }
 }

--- a/ceilometer/manifests/alarm/evaluator.pp
+++ b/ceilometer/manifests/alarm/evaluator.pp
@@ -25,6 +25,10 @@
 #    (optional) Record alarm change events
 #    Defaults to true.
 #
+#  [*coordination_url*]
+#    (optional) The url to use for distributed group membership coordination.
+#    Defaults to undef.
+#
 class ceilometer::alarm::evaluator (
   $manage_service      = true,
   $enabled             = true,
@@ -32,6 +36,7 @@ class ceilometer::alarm::evaluator (
   $evaluation_service  = 'ceilometer.alarm.service.SingletonAlarmService',
   $partition_rpc_topic = 'alarm_partition_coordination',
   $record_history      = true,
+  $coordination_url    = undef,
 ) {
 
   include ceilometer::params
@@ -67,5 +72,10 @@ class ceilometer::alarm::evaluator (
     'alarm/evaluation_service'  :  value => $evaluation_service;
     'alarm/partition_rpc_topic' :  value => $partition_rpc_topic;
     'alarm/record_history'      :  value => $record_history;
-    }
+  }
+
+  if $coordination_url {
+    ensure_resource('ceilometer_config', 'coordination/backend_url',
+      {'value' => $coordination_url})
+  }
 }

--- a/ceilometer/spec/classes/ceilometer_agent_central_spec.rb
+++ b/ceilometer/spec/classes/ceilometer_agent_central_spec.rb
@@ -7,9 +7,11 @@ describe 'ceilometer::agent::central' do
   end
 
   let :params do
-    { :enabled        => true,
-      :manage_service => true,
-      :package_ensure => 'latest' }
+    { :enabled          => true,
+      :manage_service   => true,
+      :package_ensure   => 'latest',
+      :coordination_url => 'redis://localhost:6379'
+    }
   end
 
   shared_examples_for 'ceilometer-agent-central' do
@@ -46,6 +48,10 @@ describe 'ceilometer::agent::central' do
           )
         end
       end
+    end
+
+    it 'configures central agent' do
+      should contain_ceilometer_config('coordination/backend_url').with_value( params[:coordination_url] )
     end
 
     context 'with disabled service managing' do

--- a/ceilometer/spec/classes/ceilometer_alarm_evaluator_spec.rb
+++ b/ceilometer/spec/classes/ceilometer_alarm_evaluator_spec.rb
@@ -38,6 +38,7 @@ describe 'ceilometer::alarm::evaluator' do
       should contain_ceilometer_config('alarm/evaluation_service').with_value( params[:evaluation_service] )
       should contain_ceilometer_config('alarm/partition_rpc_topic').with_value( params[:partition_rpc_topic] )
       should contain_ceilometer_config('alarm/record_history').with_value( params[:record_history] )
+      should_not contain_ceilometer_config('coordination/backend_url')
     end
 
     context 'when overriding parameters' do
@@ -45,12 +46,14 @@ describe 'ceilometer::alarm::evaluator' do
         params.merge!(:evaluation_interval => 80,
                       :partition_rpc_topic => 'alarm_partition_coordination',
                       :record_history      => false,
-                      :evaluation_service  => 'ceilometer.alarm.service.SingletonTestAlarmService')
+                      :evaluation_service  => 'ceilometer.alarm.service.SingletonTestAlarmService',
+                      :coordination_url     => 'redis://localhost:6379')
       end
       it { should contain_ceilometer_config('alarm/evaluation_interval').with_value(params[:evaluation_interval]) }
       it { should contain_ceilometer_config('alarm/evaluation_service').with_value(params[:evaluation_service]) }
       it { should contain_ceilometer_config('alarm/record_history').with_value(params[:record_history]) }
       it { should contain_ceilometer_config('alarm/partition_rpc_topic').with_value(params[:partition_rpc_topic])  }
+      it { should contain_ceilometer_config('coordination/backend_url').with_value( params[:coordination_url]) }
     end
 
     context 'when override the evaluation interval with a non numeric value' do


### PR DESCRIPTION
Changes include:
- Add support for configuring coordination/backend_url
- Clean up stray copy-paste error
- Release 5.0.0 - Juno

Hash references:
- old commit: 1d78470e5023e2ca6adef47c904d14d046dd87d1
- new commit: 64d872cdef84867728087609996e5d9993398416
