### PR TITLE
Automatic update :: puppet-ceilometer support for configuring coordination/backend_url

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,7 @@ mod 'apache',
   :git => 'https://github.com/puppetlabs/puppetlabs-apache.git'
 
 mod 'ceilometer',
-  :commit => '741e89ae5b59e6284d677dd1c3cdf4154902a378',
+  :commit => 'ee2f3cd4498b2ef3a6633991206b7185c1d32897',
   :git => 'https://github.com/stackforge/puppet-ceilometer.git'
 
 mod 'certmonger',

--- a/ceilometer/manifests/agent/central.pp
+++ b/ceilometer/manifests/agent/central.pp
@@ -13,11 +13,16 @@
 #    (optional) ensure state for package.
 #    Defaults to 'present'
 #
+#  [*coordination_url*]
+#    (optional) The url to use for distributed group membership coordination.
+#    Defaults to undef.
+#
 
 class ceilometer::agent::central (
   $manage_service   = true,
   $enabled          = true,
   $package_ensure   = 'present',
+  $coordination_url = undef,
 ) {
 
   include ceilometer::params
@@ -47,4 +52,8 @@ class ceilometer::agent::central (
     hasrestart => true,
   }
 
+  if $coordination_url {
+    ensure_resource('ceilometer_config', 'coordination/backend_url',
+      {'value' => $coordination_url})
+  }
 }

--- a/ceilometer/manifests/alarm/evaluator.pp
+++ b/ceilometer/manifests/alarm/evaluator.pp
@@ -25,6 +25,10 @@
 #    (optional) Record alarm change events
 #    Defaults to true.
 #
+#  [*coordination_url*]
+#    (optional) The url to use for distributed group membership coordination.
+#    Defaults to undef.
+#
 class ceilometer::alarm::evaluator (
   $manage_service      = true,
   $enabled             = true,
@@ -32,6 +36,7 @@ class ceilometer::alarm::evaluator (
   $evaluation_service  = 'ceilometer.alarm.service.SingletonAlarmService',
   $partition_rpc_topic = 'alarm_partition_coordination',
   $record_history      = true,
+  $coordination_url    = undef,
 ) {
 
   include ceilometer::params
@@ -67,5 +72,10 @@ class ceilometer::alarm::evaluator (
     'alarm/evaluation_service'  :  value => $evaluation_service;
     'alarm/partition_rpc_topic' :  value => $partition_rpc_topic;
     'alarm/record_history'      :  value => $record_history;
-    }
+  }
+
+  if $coordination_url {
+    ensure_resource('ceilometer_config', 'coordination/backend_url',
+      {'value' => $coordination_url})
+  }
 }

--- a/ceilometer/spec/classes/ceilometer_agent_central_spec.rb
+++ b/ceilometer/spec/classes/ceilometer_agent_central_spec.rb
@@ -7,9 +7,11 @@ describe 'ceilometer::agent::central' do
   end
 
   let :params do
-    { :enabled        => true,
-      :manage_service => true,
-      :package_ensure => 'latest' }
+    { :enabled          => true,
+      :manage_service   => true,
+      :package_ensure   => 'latest',
+      :coordination_url => 'redis://localhost:6379'
+    }
   end
 
   shared_examples_for 'ceilometer-agent-central' do
@@ -46,6 +48,10 @@ describe 'ceilometer::agent::central' do
           )
         end
       end
+    end
+
+    it 'configures central agent' do
+      should contain_ceilometer_config('coordination/backend_url').with_value( params[:coordination_url] )
     end
 
     context 'with disabled service managing' do

--- a/ceilometer/spec/classes/ceilometer_alarm_evaluator_spec.rb
+++ b/ceilometer/spec/classes/ceilometer_alarm_evaluator_spec.rb
@@ -38,6 +38,7 @@ describe 'ceilometer::alarm::evaluator' do
       should contain_ceilometer_config('alarm/evaluation_service').with_value( params[:evaluation_service] )
       should contain_ceilometer_config('alarm/partition_rpc_topic').with_value( params[:partition_rpc_topic] )
       should contain_ceilometer_config('alarm/record_history').with_value( params[:record_history] )
+      should_not contain_ceilometer_config('coordination/backend_url')
     end
 
     context 'when overriding parameters' do
@@ -45,12 +46,14 @@ describe 'ceilometer::alarm::evaluator' do
         params.merge!(:evaluation_interval => 80,
                       :partition_rpc_topic => 'alarm_partition_coordination',
                       :record_history      => false,
-                      :evaluation_service  => 'ceilometer.alarm.service.SingletonTestAlarmService')
+                      :evaluation_service  => 'ceilometer.alarm.service.SingletonTestAlarmService',
+                      :coordination_url     => 'redis://localhost:6379')
       end
       it { should contain_ceilometer_config('alarm/evaluation_interval').with_value(params[:evaluation_interval]) }
       it { should contain_ceilometer_config('alarm/evaluation_service').with_value(params[:evaluation_service]) }
       it { should contain_ceilometer_config('alarm/record_history').with_value(params[:record_history]) }
       it { should contain_ceilometer_config('alarm/partition_rpc_topic').with_value(params[:partition_rpc_topic])  }
+      it { should contain_ceilometer_config('coordination/backend_url').with_value( params[:coordination_url]) }
     end
 
     context 'when override the evaluation interval with a non numeric value' do


### PR DESCRIPTION
This module update commit was generated by Bade.
For more info please check https://github.com/paramite/bade

This commit is setting modules to following state:
ceilometer
- old commit: 741e89ae5b59e6284d677dd1c3cdf4154902a378
- new commit: ee2f3cd4498b2ef3a6633991206b7185c1d32897
