### PR TITLE
Run travis tests only on changed modules

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ev
+MODS="$(git diff HEAD~1 Puppetfile | grep ^- -B2 | grep mod | cut -d"'" -f2)"
+rake validate_puppetfile SPEC_OPTS='--format documentation --color --backtrace' || exit 1
+for module in ${MODS}; do
+  if [ -e ./${module}/Rakefile ]; then
+    rake test_modules[./${module}/Rakefile] SPEC_OPTS='--format documentation --color --backtrace' || exit 1
+  else
+    echo "Missing ./${module}/Rakefile, not running spec tests."
+  fi
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
 language: ruby
 install:
-  - gem install bundler
-  - gem install rake
-  - gem install r10k
-script: "rake test SPEC_OPTS='--format documentation --color --backtrace'"
+script: "./.travis.sh"
 rvm:
-  - 1.9.3
   - 2.0.0
 matrix:
   fast_finish: true
 env:
   matrix:
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
     - PUPPET_GEM_VERSION="~> 3.7.0"
 notifications:
   email: false

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ task(:default).clear
 task :default => :test
 
 desc 'Run Puppetfile Validation'
-task :test => [:validate_puppetfile,:all_modules]
+task :test => [:validate_puppetfile,:test_modules]
 
 desc "Validate the Puppetfile syntax"
 task :validate_puppetfile do
@@ -10,9 +10,10 @@ task :validate_puppetfile do
   sh "r10k puppetfile check"
 end
 
-desc "Run rspec tests for each modules"
-task :all_modules do
-  FileList["*/Rakefile"].each do |project|
+desc "Run rspec test on specified modules"
+task :test_modules, [:modules] do |t, args|
+  args.with_defaults(:modules => FileList["*/Rakefile"])
+  Array(args[:modules]).each do |project|
     dir = project.pathmap("%d")
     Dir.chdir(dir) do
       puts "======"


### PR DESCRIPTION
Rakefile is changed to allow specifying modules to test and travis
now runs .travis.sh which gets changed modules from Puppetfile.

(cherry picked from commit cd86b88ca206decbab2e1fa8afb26c457ec7f80b)
