### PR TITLE
Add Manila Puppet module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -62,6 +62,10 @@ mod 'keystone',
   :commit => '38518cbcb3ef8ad3bb068730a21d790b27a29b74',
   :git => 'https://github.com/stackforge/puppet-keystone.git'
 
+mod 'manila',
+  :commit => '915acf658d037a4bcd3745f9cce696b2f8b2919b',
+  :git => 'https://github.com/stackforge/puppet-manila.git'
+
 mod 'memcached',
   :commit => '49dbf102fb6eee90297b2ed6a1fa463a8c5ccee7',
   :git => 'https://github.com/saz/puppet-memcached.git'

--- a/manila/.fixtures.yml
+++ b/manila/.fixtures.yml
@@ -1,0 +1,20 @@
+fixtures:
+  repositories:
+    'apt': 'git://github.com/puppetlabs/puppetlabs-apt.git'
+    'inifile':  'git://github.com/puppetlabs/puppetlabs-inifile'
+    'keystone': 'git://github.com/stackforge/puppet-keystone.git'
+    'mysql':
+      repo: 'git://github.com/puppetlabs/puppetlabs-mysql.git'
+      ref:  'origin/2.2.x'
+    'openstacklib': 'git://github.com/stackforge/puppet-openstacklib.git'
+    'postgresql':
+      repo: 'git://github.com/puppetlabs/puppet-postgresql.git'
+      ref: '2.5.0'
+    'qpid': 'git://github.com/dprince/puppet-qpid.git'
+    'rabbitmq':
+      repo: 'git://github.com/puppetlabs/puppetlabs-rabbitmq'
+      ref: 'origin/2.x'
+    'stdlib': 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+    'sysctl': 'git://github.com/duritong/puppet-sysctl.git'
+  symlinks:
+    'manila': "#{source_dir}"

--- a/manila/.gitignore
+++ b/manila/.gitignore
@@ -1,0 +1,5 @@
+Gemfile.lock
+spec/fixtures/modules/*
+spec/fixtures/manifests/site.pp
+*.swp
+pkg

--- a/manila/.gitreview
+++ b/manila/.gitreview
@@ -1,0 +1,4 @@
+[gerrit]
+host=review.openstack.org
+port=29418
+project=stackforge/puppet-manila.git

--- a/manila/Gemfile
+++ b/manila/Gemfile
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'puppet-lint', '~> 0.3.2'
+  gem 'rake', '10.1.1'
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+# vim:ft=ruby

--- a/manila/LICENSE
+++ b/manila/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/manila/README.md
+++ b/manila/README.md
@@ -1,0 +1,70 @@
+manila
+=======
+
+1.0.0 - 2014.2.0 - Juno
+
+#### Table of Contents
+
+1. [Overview - What is the manila module?](#overview)
+2. [Module Description - What does the module do?](#module-description)
+3. [Setup - The basics of getting started with manila](#setup)
+4. [Implementation - An under-the-hood peek at what the module is doing](#implementation)
+5. [Development - Guide for contributing to the module](#development)
+6. [Contributors - Those with commits](#contributors)
+7. [Release Notes - Notes on the most recent updates to the module](#release-notes)
+
+Overview
+--------
+
+The manila module is part of [Stackforge](https://github.com/stackforge), an effort by the OpenStack infrastructure team to provide continuous integration testing and code review for OpenStack and OpenStack community projects not part of the core software.  The module its self is used to flexibly configure and manage the file system service for OpenStack.
+
+Module Description
+------------------
+
+The manila module is a thorough attempt to make Puppet capable of managing the entirety of manila.  This includes manifests to provision such things as keystone endpoints, RPC configurations specific to manila, and database connections.
+
+This module is tested in combination with other modules needed to build and leverage an entire OpenStack software stack.  These modules can be found, all pulled together in the [openstack module](https://github.com/stackfoge/puppet-openstack).
+
+Setup
+-----
+
+**What the manila module affects**
+
+* manila, the file system service for OpenStack.
+
+### Installing manila
+
+    manila is not currently in Puppet Forge, but is anticipated to be added soon.  Once that happens, you'll be able to install manila with:
+    puppet module install puppetlabs/manila
+
+### Beginning with manila
+
+To utilize the manila module's functionality you will need to declare multiple resources.  [TODO: add example]
+
+
+Implementation
+--------------
+
+### manila
+
+manila is a combination of Puppet manifests and ruby code to delivery configuration and extra functionality through types and providers.
+
+
+Development
+-----------
+
+Developer documentation for the entire puppet-openstack project.
+
+* https://wiki.openstack.org/wiki/Puppet-openstack#Developer_documentation
+
+Contributors
+------------
+
+* https://github.com/stackforge/puppet-manila/graphs/contributors
+
+Release Notes
+-------------
+
+**1.0.0**
+
+* Initial commit

--- a/manila/Rakefile
+++ b/manila/Rakefile
@@ -1,0 +1,6 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_class_parameter_defaults')

--- a/manila/lib/puppet/provider/manila_api_paste_ini/ini_setting.rb
+++ b/manila/lib/puppet/provider/manila_api_paste_ini/ini_setting.rb
@@ -1,0 +1,27 @@
+Puppet::Type.type(:manila_api_paste_ini).provide(
+  :ini_setting,
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+
+  def section
+    resource[:name].split('/', 2).first
+  end
+
+  def setting
+    resource[:name].split('/', 2).last
+  end
+
+  def separator
+    '='
+  end
+
+  def self.file_path
+    '/etc/manila/api-paste.ini'
+  end
+
+  # added for backwards compatibility with older versions of inifile
+  def file_path
+    self.class.file_path
+  end
+
+end

--- a/manila/lib/puppet/provider/manila_config/ini_setting.rb
+++ b/manila/lib/puppet/provider/manila_config/ini_setting.rb
@@ -1,0 +1,27 @@
+Puppet::Type.type(:manila_config).provide(
+  :ini_setting,
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+
+  def section
+    resource[:name].split('/', 2).first
+  end
+
+  def setting
+    resource[:name].split('/', 2).last
+  end
+
+  def separator
+    '='
+  end
+
+  def self.file_path
+    '/etc/manila/manila.conf'
+  end
+
+  # added for backwards compatibility with older versions of inifile
+  def file_path
+    self.class.file_path
+  end
+
+end

--- a/manila/lib/puppet/type/manila_api_paste_ini.rb
+++ b/manila/lib/puppet/type/manila_api_paste_ini.rb
@@ -1,0 +1,42 @@
+Puppet::Type.newtype(:manila_api_paste_ini) do
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'Section/setting name to manage from /etc/manila/api-paste.ini'
+    newvalues(/\S+\/\S+/)
+  end
+
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |value|
+      value = value.to_s.strip
+      value.capitalize! if value =~ /^(true|false)$/i
+      value
+    end
+
+    def is_to_s( currentvalue )
+      if resource.secret?
+        return '[old secret redacted]'
+      else
+        return currentvalue
+      end
+    end
+
+    def should_to_s( newvalue )
+      if resource.secret?
+        return '[new secret redacted]'
+      else
+        return newvalue
+      end
+    end
+  end
+
+  newparam(:secret, :boolean => true) do
+    desc 'Whether to hide the value from Puppet logs. Defaults to `false`.'
+
+    newvalues(:true, :false)
+
+    defaultto false
+  end
+end

--- a/manila/lib/puppet/type/manila_config.rb
+++ b/manila/lib/puppet/type/manila_config.rb
@@ -1,0 +1,42 @@
+Puppet::Type.newtype(:manila_config) do
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'Section/setting name to manage from /etc/manila/manila.conf'
+    newvalues(/\S+\/\S+/)
+  end
+
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |value|
+      value = value.to_s.strip
+      value.capitalize! if value =~ /^(true|false)$/i
+      value
+    end
+
+    def is_to_s( currentvalue )
+      if resource.secret?
+        return '[old secret redacted]'
+      else
+        return currentvalue
+      end
+    end
+
+    def should_to_s( newvalue )
+      if resource.secret?
+        return '[new secret redacted]'
+      else
+        return newvalue
+      end
+    end
+  end
+
+  newparam(:secret, :boolean => true) do
+    desc 'Whether to hide the value from Puppet logs. Defaults to `false`.'
+
+    newvalues(:true, :false)
+
+    defaultto false
+  end
+end

--- a/manila/manifests/api.pp
+++ b/manila/manifests/api.pp
@@ -1,0 +1,191 @@
+# == Class: manila::api
+#
+# Setup and configure the manila API endpoint
+#
+# === Parameters
+#
+# [*keystone_password*]
+#   The password to use for authentication (keystone)
+#
+# [*keystone_enabled*]
+#   (optional) Use keystone for authentification
+#   Defaults to true
+#
+# [*keystone_tenant*]
+#   (optional) The tenant of the auth user
+#   Defaults to services
+#
+# [*keystone_user*]
+#   (optional) The name of the auth user
+#   Defaults to manila
+#
+# [*keystone_auth_host*]
+#   (optional) The keystone host
+#   Defaults to localhost
+#
+# [*keystone_auth_port*]
+#   (optional) The keystone auth port
+#   Defaults to 35357
+#
+# [*keystone_auth_protocol*]
+#   (optional) The protocol used to access the auth host
+#   Defaults to http.
+#
+# [*os_region_name*]
+#   (optional) Some operations require manila to make API requests
+#   to Nova. This sets the keystone region to be used for these
+#   requests. For example, boot-from-share.
+#   Defaults to undef.
+#
+# [*keystone_auth_admin_prefix*]
+#   (optional) The admin_prefix used to admin endpoint of the auth host
+#   This allow admin auth URIs like http://auth_host:35357/keystone.
+#   (where '/keystone' is the admin prefix)
+#   Defaults to false for empty. If defined, should be a string with a
+#   leading '/' and no trailing '/'.
+#
+# [*service_port*]
+#   (optional) The manila api port
+#   Defaults to 5000
+#
+# [*package_ensure*]
+#   (optional) The state of the package
+#   Defaults to present
+#
+# [*bind_host*]
+#   (optional) The manila api bind address
+#   Defaults to 0.0.0.0
+#
+# [*enabled*]
+#   (optional) The state of the service
+#   Defaults to true
+#
+# [*manage_service*]
+#   (optional) Whether to start/stop the service
+#   Defaults to true
+#
+# [*ratelimits*]
+#   (optional) The state of the service
+#   Defaults to undef. If undefined the default ratelimiting values are used.
+#
+# [*ratelimits_factory*]
+#   (optional) Factory to use for ratelimiting
+#   Defaults to 'manila.api.v1.limits:RateLimitingMiddleware.factory'
+#
+class manila::api (
+  $keystone_password,
+  $keystone_enabled           = true,
+  $keystone_tenant            = 'services',
+  $keystone_user              = 'manila',
+  $keystone_auth_host         = 'localhost',
+  $keystone_auth_port         = '35357',
+  $keystone_auth_protocol     = 'http',
+  $keystone_auth_admin_prefix = false,
+  $keystone_auth_uri          = false,
+  $os_region_name             = undef,
+  $service_port               = '5000',
+  $package_ensure             = 'present',
+  $bind_host                  = '0.0.0.0',
+  $enabled                    = true,
+  $manage_service             = true,
+  $ratelimits                 = undef,
+  $ratelimits_factory =
+    'manila.api.v1.limits:RateLimitingMiddleware.factory'
+) {
+
+  include manila::params
+
+  Manila_config<||> ~> Service['manila-api']
+  Manila_api_paste_ini<||> ~> Service['manila-api']
+
+  if $::manila::params::api_package {
+    Package['manila-api'] -> Manila_config<||>
+    Package['manila-api'] -> Manila_api_paste_ini<||>
+    Package['manila-api'] -> Service['manila-api']
+    package { 'manila-api':
+      ensure  => $package_ensure,
+      name    => $::manila::params::api_package,
+    }
+  }
+
+  if $enabled {
+
+    Manila_config<||> ~> Exec['manila-manage db_sync']
+
+    exec { 'manila-manage db_sync':
+      command     => $::manila::params::db_sync_command,
+      path        => '/usr/bin',
+      user        => 'manila',
+      refreshonly => true,
+      logoutput   => 'on_failure',
+      require     => Package['manila'],
+    }
+    if $manage_service {
+      $ensure = 'running'
+    }
+  } else {
+    if $manage_service {
+      $ensure = 'stopped'
+    }
+  }
+
+  service { 'manila-api':
+    ensure    => $ensure,
+    name      => $::manila::params::api_service,
+    enable    => $enabled,
+    hasstatus => true,
+    require   => Package['manila'],
+  }
+
+  manila_config {
+    'DEFAULT/osapi_share_listen': value => $bind_host
+  }
+
+  if $os_region_name {
+    manila_config {
+      'DEFAULT/os_region_name': value => $os_region_name;
+    }
+  }
+
+  if $keystone_auth_uri {
+    manila_api_paste_ini { 'filter:authtoken/auth_uri': value => $keystone_auth_uri; }
+  } else {
+    manila_api_paste_ini { 'filter:authtoken/auth_uri': value => "${keystone_auth_protocol}://${keystone_auth_host}:${service_port}/"; }
+  }
+
+  if $keystone_enabled {
+    manila_config {
+      'DEFAULT/auth_strategy':     value => 'keystone' ;
+    }
+    manila_api_paste_ini {
+      'filter:authtoken/service_protocol':  value => $keystone_auth_protocol;
+      'filter:authtoken/service_host':      value => $keystone_auth_host;
+      'filter:authtoken/service_port':      value => $service_port;
+      'filter:authtoken/auth_protocol':     value => $keystone_auth_protocol;
+      'filter:authtoken/auth_host':         value => $keystone_auth_host;
+      'filter:authtoken/auth_port':         value => $keystone_auth_port;
+      'filter:authtoken/admin_tenant_name': value => $keystone_tenant;
+      'filter:authtoken/admin_user':        value => $keystone_user;
+      'filter:authtoken/admin_password':    value => $keystone_password, secret => true;
+    }
+
+  if ($ratelimits != undef) {
+    manila_api_paste_ini {
+      'filter:ratelimit/paste.filter_factory': value => $ratelimits_factory;
+      'filter:ratelimit/limits':               value => $ratelimits;
+    }
+  }
+
+    if $keystone_auth_admin_prefix {
+      validate_re($keystone_auth_admin_prefix, '^(/.+[^/])?$')
+      manila_api_paste_ini {
+        'filter:authtoken/auth_admin_prefix': value => $keystone_auth_admin_prefix;
+      }
+    } else {
+      manila_api_paste_ini {
+        'filter:authtoken/auth_admin_prefix': ensure => absent;
+      }
+    }
+  }
+
+}

--- a/manila/manifests/backend/generic.pp
+++ b/manila/manifests/backend/generic.pp
@@ -1,0 +1,75 @@
+# ==define manila::backend::generic
+#
+# ===Parameters
+# [*share_backend_name*]
+#   (optional) Name of the backend in manila.conf that
+#   these settings will reside in
+#
+# [*smb_template_config_path*]
+#   (optional) Path to smb config.
+#   Defaults to: $state_path/smb.conf
+#
+# [*volume_name_template*]
+#   (optional) Volume name template.
+#   Defaults to: manila-share-%s
+#
+# [*volume_snapshot_name_template*]
+#   (optional) Volume snapshot name template.
+#   Defaults to: manila-snapshot-%s
+#
+# [*share_mount_path*]
+#   (optional) Parent path in service instance where shares will be mounted.
+#   Defaults to: /shares
+#
+# [*max_time_to_create_volume*]
+#   (optional) Maximum time to wait for creating cinder volume.
+#   Defaults to: 180
+#
+# [*max_time_to_attach*]
+#   (optional) Maximum time to wait for attaching cinder volume.
+#   Defaults to: 120
+#
+# [*service_instance_smb_config_path*]
+#   (optional) Path to smb config in service instance.
+#   Defaults to: $share_mount_path/smb.conf
+#
+# [*share_volume_fstype*]
+#   (optional) Filesystem type of the share volume.
+#   Choices: 'ext4', 'ext3'
+#   Defaults to: ext4
+#
+# [*share_helpers*]
+#   (optional) Specify list of share export helpers.
+#   Defaults to: ['CIFS=manila.share.drivers.generic.CIFSHelper',
+#                'NFS=manila.share.drivers.generic.NFSHelper']
+#
+define manila::backend::generic (
+  $share_backend_name               = $name,
+  $smb_template_config_path         = '$state_path/smb.conf',
+  $volume_name_template             = 'manila-share-%s',
+  $volume_snapshot_name_template    = 'manila-snapshot-%s',
+  $share_mount_path                 = '/shares',
+  $max_time_to_create_volume        = 180,
+  $max_time_to_attach               = 120,
+  $service_instance_smb_config_path = '$share_mount_path/smb.conf',
+  $share_volume_fstype              = 'ext4',
+  $share_helpers = ['CIFS=manila.share.drivers.generic.CIFSHelper',
+                    'NFS=manila.share.drivers.generic.NFSHelper'],
+) {
+
+  $share_driver = 'manila.share.drivers.generic.GenericShareDriver'
+
+  manila_config {
+    "${name}/share_backend_name":               value => $share_backend_name;
+    "${name}/share_driver":                     value => $share_driver;
+    "${name}/smb_template_config_path":         value => $smb_template_config_path;
+    "${name}/volume_name_template":             value => $volume_name_template;
+    "${name}/volume_snapshot_name_template":    value => $volume_snapshot_name_template;
+    "${name}/share_mount_path":                 value => $share_mount_path;
+    "${name}/max_time_to_create_volume":        value => $max_time_to_create_volume;
+    "${name}/max_time_to_attach":               value => $max_time_to_attach;
+    "${name}/service_instance_smb_config_path": value => $service_instance_smb_config_path;
+    "${name}/share_volume_fstype":              value => $share_volume_fstype;
+    "${name}/share_helpers":                    value => $share_helpers;
+  }
+}

--- a/manila/manifests/backend/glusterfs.pp
+++ b/manila/manifests/backend/glusterfs.pp
@@ -1,0 +1,39 @@
+#
+# == Class: manila::backend::glusterfs
+#
+# Configures Manila to use GlusterFS as a share driver
+#
+# === Parameters
+# [*share_backend_name*]
+#   (optional) Name of the backend in manila.conf that
+#   these settings will reside in
+#
+# [*glusterfs_volumes_config*]
+#   (required) File with the list of Gluster volumes that can be used to
+#   create shares
+#   Default to: /etc/manila/glusterfs_volumes
+#
+# [*glusterfs_mount_point_base*]
+#   (optional) Base dir containing mount points for Gluster volumes.
+#   Defaults to: $state_path/mnt
+#
+# === Examples
+# manila::backend::glusterfs { 'myGluster':
+#   glusterfs_shares = ['192.168.1.1:/shares'],
+# }
+#
+define manila::backend::glusterfs (
+  $share_backend_name         = $name,
+  $glusterfs_volumes_config   = '/etc/manila/glusterfs_volumes',
+  $glusterfs_mount_point_base = '$state_path/mnt',
+) {
+
+  $share_driver = 'manila.share.drivers.glusterfs.GlusterfsShareDriver'
+
+  manila_config {
+    "${name}/share_backend_name":          value => $share_backend_name;
+    "${name}/share_driver":                value => $share_driver;
+    "${name}/glusterfs_volumes_config":    value => $glusterfs_volumes_config;
+    "${name}/glusterfs_mount_point_base":  value => $glusterfs_mount_point_base;
+  }
+}

--- a/manila/manifests/backend/netapp.pp
+++ b/manila/manifests/backend/netapp.pp
@@ -1,0 +1,91 @@
+# == define: manila::backend::netapp
+#
+# Configures Manila to use the NetApp unified share driver
+# Compatible for multiple backends
+#
+# === Parameters
+# NTAP: check if these parameters are actually optional or required
+#
+# [*share_backend_name*]
+#   (optional) Name of the backend in manila.conf that
+#   these settings will reside in
+#
+# [*netapp_nas_transport_type*]
+#   (optional) The transport protocol used when communicating with ONTAPI on the
+#   storage system or proxy server. Valid values are http or https.
+#   Defaults to http
+#
+# [*netapp_nas_login*]
+#   (required) Administrative user account name used to access the storage
+#   system or proxy server.
+#
+# [*netapp_nas_password*]
+#   (required) Password for the administrative user account specified in the
+#   netapp_nas_login parameter.
+#
+# [*netapp_nas_server_hostname*]
+#   (required) The hostname (or IP address) for the storage system or proxy
+#   server.
+#
+# [*netapp_nas_volume_name_template*]
+#   (optional) NetApp volume name template.
+#
+# [*netapp_vserver_name_template*]
+#   (optional) Name template to use for new vserver.
+#
+# [*netapp_lif_name_template*]
+#   (optional) Lif name template
+#
+# [*netapp_aggregate_name_search_pattern*]
+#   (optional) Pattern for searching available aggregates
+#   for provisioning.
+#
+# [*netapp_root_volume_aggregate*]
+#   (optional) Name of aggregate to create root volume on.
+#
+# [*netapp_root_volume_name*]
+#   (optional) Root volume name.
+#
+# === Examples
+#
+#  manila::backend::netapp { 'myBackend':
+#    netapp_nas_login           => 'clusterAdmin',
+#    netapp_nas_password        => 'password',
+#    netapp_nas_server_hostname => 'netapp.mycorp.com',
+#    netapp_nas_transport_type  => 'https',
+#  }
+
+define manila::backend::netapp (
+  $share_backend_name                   = $name,
+  $netapp_nas_transport_type            = 'http',
+  $netapp_nas_login                     = 'admin',
+  $netapp_nas_password                  = undef,
+  $netapp_nas_server_hostname           = undef,
+  $netapp_nas_volume_name_template      = 'share_%(share_id)s',
+  $netapp_vserver_name_template         = 'os_%s',
+  $netapp_lif_name_template             = 'os_%(net_allocation_id)s',
+  $netapp_aggregate_name_search_pattern  = '(.*)',
+  $netapp_root_volume_aggregate         = undef,
+  $netapp_root_volume_name              = 'root',
+) {
+
+  $netapp_share_driver = 'manila.share.drivers.netapp.cluster_mode.NetAppClusteredShareDriver'
+
+  manila_config {
+    'DEFAULT/enabled_share_backends':                             value => $share_backend_name;
+    "${share_backend_name}/share_backend_name":                   value => $share_backend_name;
+    "${share_backend_name}/share_driver":                         value => $netapp_share_driver;
+    "${share_backend_name}/netapp_nas_transport_type":            value => $netapp_nas_transport_type;
+    "${share_backend_name}/netapp_nas_login":                     value => $netapp_nas_login;
+    "${share_backend_name}/netapp_nas_password":                  value => $netapp_nas_password, secret => true;
+    "${share_backend_name}/netapp_nas_server_hostname":           value => $netapp_nas_server_hostname;
+    "${share_backend_name}/netapp_nas_volume_name_template":      value => $netapp_nas_volume_name_template;
+    "${share_backend_name}/netapp_vserver_name_template":         value => $netapp_vserver_name_template;
+    "${share_backend_name}/netapp_lif_name_template":             value => $netapp_lif_name_template;
+    "${share_backend_name}/netapp_aggregate_name_search_pattern": value => $netapp_aggregate_name_search_pattern;
+    "${share_backend_name}/netapp_root_volume_aggregate":         value => $netapp_root_volume_aggregate;
+    "${share_backend_name}/netapp_root_volume_name":              value => $netapp_root_volume_name;
+  }
+
+  package { 'nfs-utils': ensure => present }
+}

--- a/manila/manifests/backends.pp
+++ b/manila/manifests/backends.pp
@@ -1,0 +1,22 @@
+# == Class: manila::backends
+#
+# Class to set the enabled_backends list
+#
+# === Parameters
+#
+# [*enabled_backends*]
+#   (required) a list of ini sections to enable.
+#     This should contain names used in ceph::backend::* resources.
+#     Example: ['share1', 'share2', 'sata3']
+#
+# Author: Andrew Woodward <awoodward@mirantis.com>
+class manila::backends (
+  $enabled_share_backends    = undef
+  ){
+
+  # Maybe this could be extented to dynamicly find the enabled names
+  manila_config {
+    'DEFAULT/enabled_share_backends': value => join($enabled_share_backends, ',');
+  }
+
+}

--- a/manila/manifests/client.pp
+++ b/manila/manifests/client.pp
@@ -1,0 +1,20 @@
+# == Class: manila::client
+#
+# Installs Manila python client.
+#
+# === Parameters
+#
+# [*ensure*]
+#   Ensure state for package. Defaults to 'present'.
+#
+class manila::client(
+  $package_ensure = 'present'
+) {
+
+  include manila::params
+
+  package { 'python-manilaclient':
+    ensure => $package_ensure,
+    name   => $::manila::params::client_package,
+  }
+}

--- a/manila/manifests/compute/nova.pp
+++ b/manila/manifests/compute/nova.pp
@@ -1,0 +1,59 @@
+# == Class: manila::nova
+#
+# Setup and configure Nova communication
+#
+# === Parameters
+#
+# [*nova_catalog_info*]
+# (optional) Info to match when looking for nova in the service
+# catalog. Format is : separated values of the form:
+# <service_type>:<service_name>:<endpoint_type>
+#
+# [*nova_catalog_admin_info*]
+# (optional) Same as nova_catalog_info, but for admin endpoint.
+#
+# [*os_region_name*]
+# (optional) region name of this node
+#
+# [*nova_ca_certificates_file*]
+# (optional) Location of ca certicates file to use for nova client
+# requests.
+#
+# [*nova_api_insecure*]
+# (optional) Allow to perform insecure SSL requests to nova
+#
+# [*nova_admin_username*]
+# (optional) Nova admin username
+#
+# [*nova_admin_password*]
+# (optional) Nova admin password
+#
+# [*nova_admin_tenant_name*]
+# (optional) Nova admin tenant name
+#
+# [*nova_admin_auth_url*]
+# (optional) Identity service url
+#
+
+class manila::compute::nova (
+  $nova_catalog_info         = 'compute:nova:publicURL',
+  $nova_catalog_admin_info   = 'compute:nova:adminURL',
+  $nova_ca_certificates_file = undef,
+  $nova_api_insecure         = false,
+  $nova_admin_username       = 'nova',
+  $nova_admin_password       = undef,
+  $nova_admin_tenant_name    = 'service',
+  $nova_admin_auth_url       = 'http://localhost:5000/v2.0',
+) {
+
+manila_config {
+  'DEFAULT/nova_catalog_info':        value => $nova_catalog_info;
+  'DEFAULT/nova_catalog_admin_info':  value => $nova_catalog_admin_info;
+  'DEFAULT/nova_ca_certificates_file':value => $nova_ca_certificates_file;
+  'DEFAULT/nova_api_insecure':        value => $nova_api_insecure;
+  'DEFAULT/nova_admin_username':      value => $nova_admin_username;
+  'DEFAULT/nova_admin_password':      value => $nova_admin_password;
+  'DEFAULT/nova_admin_tenant_name':   value => $nova_admin_tenant_name;
+  'DEFAULT/nova_admin_auth_url':      value => $nova_admin_auth_url;
+  }
+}

--- a/manila/manifests/config.pp
+++ b/manila/manifests/config.pp
@@ -1,0 +1,39 @@
+# == Class: manila::config
+#
+# This class is used to manage arbitrary manila configurations.
+#
+# === Parameters
+#
+# [*xxx_config*]
+#   (optional) Allow configuration of arbitrary manila configurations.
+#   The value is an hash of xxx_config resources. Example:
+#   { 'DEFAULT/foo' => { value => 'fooValue'},
+#     'DEFAULT/bar' => { value => 'barValue'}
+#   }
+#
+#   In yaml format, Example:
+#   xxx_config:
+#     DEFAULT/foo:
+#       value: fooValue
+#     DEFAULT/bar:
+#       value: barValue
+#
+# [**manila_config**]
+#   (optional) Allow configuration of manila.conf configurations.
+#
+# [**api_paste_ini_config**]
+#   (optional) Allow configuration of /etc/manila/api-paste.ini configurations.
+#
+#   NOTE: The configuration MUST NOT be already handled by this module
+#   or Puppet catalog compilation will fail with duplicate resources.
+#
+class manila::config (
+  $manila_config         = {},
+  $api_paste_ini_config  = {},
+) {
+  validate_hash($manila_config)
+  validate_hash($api_paste_ini_config)
+
+  create_resources('manila_config', $manila_config)
+  create_resources('manila_api_paste_ini', $api_paste_ini_config)
+}

--- a/manila/manifests/db/mysql.pp
+++ b/manila/manifests/db/mysql.pp
@@ -1,0 +1,61 @@
+# The manila::db::mysql class creates a MySQL database for manila.
+# It must be used on the MySQL server
+#
+# == Parameters
+#
+#  [*password*]
+#    password to connect to the database. Mandatory.
+#
+#  [*dbname*]
+#    name of the database. Optional. Defaults to manila.
+#
+#  [*user*]
+#    user to connect to the database. Optional. Defaults to manila.
+#
+#  [*host*]
+#    the default source host user is allowed to connect from.
+#    Optional. Defaults to 'localhost'
+#
+#  [*allowed_hosts*]
+#    other hosts the user is allowd to connect from.
+#    Optional. Defaults to undef.
+#
+#  [*charset*]
+#    the database charset. Optional. Defaults to 'utf8'
+#
+#  [*collate*]
+#    the database collation. Optional. Defaults to 'utf8_unicode_ci'
+#
+#  [*mysql_module*]
+#   (optional) Deprecated. Does nothing.
+#
+class manila::db::mysql (
+  $password,
+  $dbname        = 'manila',
+  $user          = 'manila',
+  $host          = '127.0.0.1',
+  $allowed_hosts = undef,
+  $charset       = 'utf8',
+  $collate       = 'utf8_unicode_ci',
+  $cluster_id    = 'localzone',
+  $mysql_module  = undef,
+) {
+
+  if $mysql_module {
+    warning('The mysql_module parameter is deprecated. The latest 2.x mysql module will be used.')
+  }
+
+  validate_string($password)
+
+  ::openstacklib::db::mysql { 'manila':
+    user          => $user,
+    password_hash => mysql_password($password),
+    dbname        => $dbname,
+    host          => $host,
+    charset       => $charset,
+    collate       => $collate,
+    allowed_hosts => $allowed_hosts,
+  }
+
+  ::Openstacklib::Db::Mysql['manila'] ~> Exec<| title == 'manila-manage db_sync' |>
+}

--- a/manila/manifests/db/postgresql.pp
+++ b/manila/manifests/db/postgresql.pp
@@ -1,0 +1,21 @@
+#
+# Class that configures postgresql for manila
+#
+# Requires the Puppetlabs postgresql module.
+class manila::db::postgresql(
+  $password,
+  $dbname = 'manila',
+  $user   = 'manila'
+) {
+
+  require postgresql::python
+
+  Postgresql::Db[$dbname]    ~> Exec<| title == 'manila-manage db_sync' |>
+  Package['python-psycopg2'] -> Exec<| title == 'manila-manage db_sync' |>
+
+  postgresql::db { $dbname:
+    user      =>  $user,
+    password  =>  $password,
+  }
+
+}

--- a/manila/manifests/db/sync.pp
+++ b/manila/manifests/db/sync.pp
@@ -1,0 +1,14 @@
+#
+class manila::db::sync {
+
+  include manila::params
+
+  exec { 'manila-manage db_sync':
+    command     => $::manila::params::db_sync_command,
+    path        => '/usr/bin',
+    user        => 'manila',
+    refreshonly => true,
+    require     => [File[$::manila::params::manila_conf], Class['manila']],
+    logoutput   => 'on_failure',
+  }
+}

--- a/manila/manifests/init.pp
+++ b/manila/manifests/init.pp
@@ -1,0 +1,320 @@
+#
+# == Parameters
+# [sql_connection]
+#    Url used to connect to database.
+#    (Optional) Defaults to
+#    'sqlite:////var/lib/manila/manila.sqlite'
+#
+# [sql_idle_timeout]
+#   Timeout when db connections should be reaped.
+#   (Optional) Defaults to 3600.
+#
+# [*rabbit_use_ssl*]
+#   (optional) Connect over SSL for RabbitMQ
+#   Defaults to false
+#
+# [*kombu_ssl_ca_certs*]
+#   (optional) SSL certification authority file (valid only if SSL enabled).
+#   Defaults to undef
+#
+# [*kombu_ssl_certfile*]
+#   (optional) SSL cert file (valid only if SSL enabled).
+#   Defaults to undef
+#
+# [*kombu_ssl_keyfile*]
+#   (optional) SSL key file (valid only if SSL enabled).
+#   Defaults to undef
+#
+# [*kombu_ssl_version*]
+#   (optional) SSL version to use (valid only if SSL enabled).
+#   Valid values are TLSv1, SSLv23 and SSLv3. SSLv2 may be
+#   available on some distributions.
+#   Defaults to 'SSLv3'
+#
+# [amqp_durable_queues]
+#   Use durable queues in amqp.
+#   (Optional) Defaults to false.
+#
+# [use_syslog]
+#   Use syslog for logging.
+#   (Optional) Defaults to false.
+#
+# [log_facility]
+#   Syslog facility to receive log lines.
+#   (Optional) Defaults to LOG_USER.
+#
+# [*log_dir*]
+#   (optional) Directory where logs should be stored.
+#   If set to boolean false, it will not log to any directory.
+#   Defaults to '/var/log/manila'
+#
+# [*use_ssl*]
+#   (optional) Enable SSL on the API server
+#   Defaults to false, not set
+#
+# [*cert_file*]
+#   (optinal) Certificate file to use when starting API server securely
+#   Defaults to false, not set
+#
+# [*key_file*]
+#   (optional) Private key file to use when starting API server securely
+#   Defaults to false, not set
+#
+# [*ca_file*]
+#   (optional) CA certificate file to use to verify connecting clients
+#   Defaults to false, not set_
+#
+# [*storage_availability_zone*]
+#   (optional) Availability zone of the node.
+#   Defaults to 'nova'
+#
+# [*rootwrap_config*]
+# (optional) Path to the rootwrap configuration file to use for
+# running commands as root
+#
+class manila (
+  $sql_connection              = 'sqlite:////var/lib/manila/manila.sqlite',
+  $sql_idle_timeout            = '3600',
+  $rpc_backend                 = 'manila.openstack.common.rpc.impl_kombu',
+  $control_exchange            = 'openstack',
+  $rabbit_host                 = '127.0.0.1',
+  $rabbit_port                 = 5672,
+  $rabbit_hosts                = false,
+  $rabbit_virtual_host         = '/',
+  $rabbit_userid               = 'guest',
+  $rabbit_password             = false,
+  $rabbit_use_ssl              = false,
+  $kombu_ssl_ca_certs          = undef,
+  $kombu_ssl_certfile          = undef,
+  $kombu_ssl_keyfile           = undef,
+  $kombu_ssl_version           = 'SSLv3',
+  $amqp_durable_queues         = false,
+  $qpid_hostname               = 'localhost',
+  $qpid_port                   = '5672',
+  $qpid_username               = 'guest',
+  $qpid_password               = false,
+  $qpid_sasl_mechanisms        = false,
+  $qpid_reconnect              = true,
+  $qpid_reconnect_timeout      = 0,
+  $qpid_reconnect_limit        = 0,
+  $qpid_reconnect_interval_min = 0,
+  $qpid_reconnect_interval_max = 0,
+  $qpid_reconnect_interval     = 0,
+  $qpid_heartbeat              = 60,
+  $qpid_protocol               = 'tcp',
+  $qpid_tcp_nodelay            = true,
+  $package_ensure              = 'present',
+  $use_ssl                     = false,
+  $ca_file                     = false,
+  $cert_file                   = false,
+  $key_file                    = false,
+  $api_paste_config            = '/etc/manila/api-paste.ini',
+  $use_syslog                  = false,
+  $log_facility                = 'LOG_USER',
+  $log_dir                     = '/var/log/manila',
+  $verbose                     = false,
+  $debug                       = false,
+  $storage_availability_zone   = 'nova',
+  $rootwrap_config             = '/etc/manila/rootwrap.conf',
+) {
+
+  include manila::params
+
+  Package['manila'] -> Manila_config<||>
+  Package['manila'] -> Manila_api_paste_ini<||>
+
+  if $use_ssl {
+    if !$cert_file {
+      fail('The cert_file parameter is required when use_ssl is set to true')
+    }
+    if !$key_file {
+      fail('The key_file parameter is required when use_ssl is set to true')
+    }
+  }
+
+  if $rabbit_use_ssl {
+    if !$kombu_ssl_ca_certs {
+      fail('The kombu_ssl_ca_certs parameter is required when rabbit_use_ssl is set to true')
+    }
+    if !$kombu_ssl_certfile {
+      fail('The kombu_ssl_certfile parameter is required when rabbit_use_ssl is set to true')
+    }
+    if !$kombu_ssl_keyfile {
+      fail('The kombu_ssl_keyfile parameter is required when rabbit_use_ssl is set to true')
+    }
+  }
+
+  # this anchor is used to simplify the graph between manila components by
+  # allowing a resource to serve as a point where the configuration of manila begins
+  anchor { 'manila-start': }
+
+  package { 'manila':
+    ensure  => $package_ensure,
+    name    => $::manila::params::package_name,
+    require => Anchor['manila-start'],
+  }
+
+  file { $::manila::params::manila_conf:
+    ensure  => present,
+    owner   => 'manila',
+    group   => 'manila',
+    mode    => '0600',
+    require => Package['manila'],
+  }
+
+  file { $::manila::params::manila_paste_api_ini:
+    ensure  => present,
+    owner   => 'manila',
+    group   => 'manila',
+    mode    => '0600',
+    require => Package['manila'],
+  }
+
+  if $rpc_backend == 'manila.openstack.common.rpc.impl_kombu' {
+
+    if ! $rabbit_password {
+      fail('Please specify a rabbit_password parameter.')
+    }
+
+    manila_config {
+      'DEFAULT/rabbit_password':     value => $rabbit_password, secret => true;
+      'DEFAULT/rabbit_userid':       value => $rabbit_userid;
+      'DEFAULT/rabbit_virtual_host': value => $rabbit_virtual_host;
+      'DEFAULT/rabbit_use_ssl':      value => $rabbit_use_ssl;
+      'DEFAULT/control_exchange':    value => $control_exchange;
+      'DEFAULT/amqp_durable_queues': value => $amqp_durable_queues;
+    }
+
+    if $rabbit_hosts {
+      manila_config { 'DEFAULT/rabbit_hosts':     value => join($rabbit_hosts, ',') }
+      manila_config { 'DEFAULT/rabbit_ha_queues': value => true }
+    } else {
+      manila_config { 'DEFAULT/rabbit_host':      value => $rabbit_host }
+      manila_config { 'DEFAULT/rabbit_port':      value => $rabbit_port }
+      manila_config { 'DEFAULT/rabbit_hosts':     value => "${rabbit_host}:${rabbit_port}" }
+      manila_config { 'DEFAULT/rabbit_ha_queues': value => false }
+    }
+
+    if $rabbit_use_ssl {
+      manila_config {
+        'DEFAULT/kombu_ssl_ca_certs': value => $kombu_ssl_ca_certs;
+        'DEFAULT/kombu_ssl_certfile': value => $kombu_ssl_certfile;
+        'DEFAULT/kombu_ssl_keyfile':  value => $kombu_ssl_keyfile;
+        'DEFAULT/kombu_ssl_version':  value => $kombu_ssl_version;
+      }
+    } else {
+      manila_config {
+        'DEFAULT/kombu_ssl_ca_certs': ensure => absent;
+        'DEFAULT/kombu_ssl_certfile': ensure => absent;
+        'DEFAULT/kombu_ssl_keyfile':  ensure => absent;
+        'DEFAULT/kombu_ssl_version':  ensure => absent;
+      }
+    }
+
+  }
+
+  if $rpc_backend == 'manila.openstack.common.rpc.impl_qpid' {
+
+    if ! $qpid_password {
+      fail('Please specify a qpid_password parameter.')
+    }
+
+    manila_config {
+      'DEFAULT/qpid_hostname':               value => $qpid_hostname;
+      'DEFAULT/qpid_port':                   value => $qpid_port;
+      'DEFAULT/qpid_username':               value => $qpid_username;
+      'DEFAULT/qpid_password':               value => $qpid_password, secret => true;
+      'DEFAULT/qpid_reconnect':              value => $qpid_reconnect;
+      'DEFAULT/qpid_reconnect_timeout':      value => $qpid_reconnect_timeout;
+      'DEFAULT/qpid_reconnect_limit':        value => $qpid_reconnect_limit;
+      'DEFAULT/qpid_reconnect_interval_min': value => $qpid_reconnect_interval_min;
+      'DEFAULT/qpid_reconnect_interval_max': value => $qpid_reconnect_interval_max;
+      'DEFAULT/qpid_reconnect_interval':     value => $qpid_reconnect_interval;
+      'DEFAULT/qpid_heartbeat':              value => $qpid_heartbeat;
+      'DEFAULT/qpid_protocol':               value => $qpid_protocol;
+      'DEFAULT/qpid_tcp_nodelay':            value => $qpid_tcp_nodelay;
+      'DEFAULT/amqp_durable_queues':         value => $amqp_durable_queues;
+    }
+
+    if is_array($qpid_sasl_mechanisms) {
+      manila_config {
+        'DEFAULT/qpid_sasl_mechanisms': value => join($qpid_sasl_mechanisms, ' ');
+      }
+    } elsif $qpid_sasl_mechanisms {
+      manila_config {
+        'DEFAULT/qpid_sasl_mechanisms': value => $qpid_sasl_mechanisms;
+      }
+    } else {
+      manila_config {
+        'DEFAULT/qpid_sasl_mechanisms': ensure => absent;
+      }
+    }
+  }
+
+  manila_config {
+    'DEFAULT/sql_connection':            value => $sql_connection, secret => true;
+    'DEFAULT/sql_idle_timeout':          value => $sql_idle_timeout;
+    'DEFAULT/verbose':                   value => $verbose;
+    'DEFAULT/debug':                     value => $debug;
+    'DEFAULT/api_paste_config':          value => $api_paste_config;
+    'DEFAULT/rpc_backend':               value => $rpc_backend;
+    'DEFAULT/storage_availability_zone': value => $storage_availability_zone;
+    'DEFAULT/rootwrap_config':           value => $rootwrap_config;
+  }
+
+  if($sql_connection =~ /mysql:\/\/\S+:\S+@\S+\/\S+/) {
+    require 'mysql::bindings'
+    require 'mysql::bindings::python'
+  } elsif($sql_connection =~ /postgresql:\/\/\S+:\S+@\S+\/\S+/) {
+
+  } elsif($sql_connection =~ /sqlite:\/\//) {
+
+  } else {
+    fail("Invalid db connection ${sql_connection}")
+  }
+
+  if $log_dir {
+    manila_config {
+      'DEFAULT/log_dir': value => $log_dir;
+    }
+  } else {
+    manila_config {
+      'DEFAULT/log_dir': ensure => absent;
+    }
+  }
+
+  # SSL Options
+  if $use_ssl {
+    manila_config {
+      'DEFAULT/ssl_cert_file' : value => $cert_file;
+      'DEFAULT/ssl_key_file' :  value => $key_file;
+    }
+    if $ca_file {
+      manila_config { 'DEFAULT/ssl_ca_file' :
+        value => $ca_file,
+      }
+    } else {
+      manila_config { 'DEFAULT/ssl_ca_file' :
+        ensure => absent,
+      }
+    }
+  } else {
+    manila_config {
+      'DEFAULT/ssl_cert_file' : ensure => absent;
+      'DEFAULT/ssl_key_file' :  ensure => absent;
+      'DEFAULT/ssl_ca_file' :   ensure => absent;
+    }
+  }
+
+  if $use_syslog {
+    manila_config {
+      'DEFAULT/use_syslog':           value => true;
+      'DEFAULT/syslog_log_facility':  value => $log_facility;
+    }
+  } else {
+    manila_config {
+      'DEFAULT/use_syslog':           value => false;
+    }
+  }
+
+}

--- a/manila/manifests/keystone/auth.pp
+++ b/manila/manifests/keystone/auth.pp
@@ -1,0 +1,88 @@
+# == Class: manila::keystone::auth
+#
+# Configures Manila user, service and endpoint in Keystone.
+#
+# === Parameters
+#
+# [*password*]
+#   Password for Manila user. Required.
+#
+# [*email*]
+#   Email for Manila user. Optional. Defaults to 'manila@localhost'.
+#
+# [*auth_name*]
+#   Username for Manila service. Optional. Defaults to 'manila'.
+#
+# [*configure_endpoint*]
+#   Should Manila endpoint be configured? Optional. Defaults to 'true'.
+#   API v1 endpoint should be enabled in Icehouse for compatibility with Nova.
+#
+# [*service_type*]
+#    Type of service. Optional. Defaults to 'share'.
+#
+# [*public_address*]
+#    Public address for endpoint. Optional. Defaults to '127.0.0.1'.
+#
+# [*admin_address*]
+#    Admin address for endpoint. Optional. Defaults to '127.0.0.1'.
+#
+# [*internal_address*]
+#    Internal address for endpoint. Optional. Defaults to '127.0.0.1'.
+#
+# [*port*]
+#    Port for endpoint. Optional. Defaults to '8786'.
+#
+# [*share_version*]
+#    Manila API version. Optional. Defaults to 'v1'.
+#
+# [*region*]
+#    Region for endpoint. Optional. Defaults to 'RegionOne'.
+#
+# [*tenant*]
+#    Tenant for Manila user. Optional. Defaults to 'services'.
+#
+# [*public_protocol*]
+#    Protocol for public endpoint. Optional. Defaults to 'http'.
+#
+# [*internal_protocol*]
+#    Protocol for internal endpoint. Optional. Defaults to 'http'.
+#
+# [*admin_protocol*]
+#    Protocol for admin endpoint. Optional. Defaults to 'http'.
+#
+class manila::keystone::auth (
+  $password,
+  $auth_name             = 'manila',
+  $email                 = 'manila@localhost',
+  $tenant                = 'services',
+  $configure_endpoint    = true,
+  $service_type          = 'share',
+  $public_address        = '127.0.0.1',
+  $admin_address         = '127.0.0.1',
+  $internal_address      = '127.0.0.1',
+  $port                  = '8786',
+  $share_version         = 'v1',
+  $region                = 'RegionOne',
+  $public_protocol       = 'http',
+  $admin_protocol        = 'http',
+  $internal_protocol     = 'http'
+) {
+
+  Keystone_user_role["${auth_name}@${tenant}"] ~> Service <| name == 'manila-api' |>
+
+  keystone::resource::service_identity { $auth_name:
+    configure_user      => true,
+    configure_user_role => true,
+    configure_endpoint  => $configure_endpoint,
+    service_type        => $service_type,
+    service_description => 'Manila Service',
+    region              => $region,
+    password            => $password,
+    email               => $email,
+    tenant              => $tenant,
+    public_url          => "${public_protocol}://${public_address}:${port}/${share_version}/%(tenant_id)s",
+    admin_url           => "${admin_protocol}://${admin_address}:${port}/${share_version}/%(tenant_id)s",
+    internal_url        => "${internal_protocol}://${internal_address}:${port}/${share_version}/%(tenant_id)s",
+  }
+
+}

--- a/manila/manifests/network/neutron.pp
+++ b/manila/manifests/network/neutron.pp
@@ -1,0 +1,70 @@
+# == Class: manila::neutron
+#
+# Setup and configure Neutron communication
+#
+# === Parameters
+#
+# [*neutron_url*]
+# (optional) URL for connecting to neutron
+#
+# [*neutron_url_timeout*]
+# (optional) timeout value for connecting to neutron in seconds
+#
+# [*neutron_admin_username*]
+# (optional) username for connecting to neutron in admin context
+#
+# [*neutron_admin_password*]
+# (optional) password for connecting to neutron in admin context
+#
+# [*neutron_admin_tenant_name*]
+# (optional) tenant name for connecting to neutron in admin context
+#
+# [*neutron_region_name*]
+# (optional) region name for connecting to neutron in admin context
+#
+# [*neutron_admin_auth_url*]
+# (optional) auth url for connecting to neutron in admin context
+#
+# [*neutron_api_insecure*]
+# (optional) if set, ignore any SSL validation issues
+#
+# [*neutron_auth_strategy*]
+# (optional) auth strategy for connecting to
+# neutron in admin context
+#
+# [*neutron_ovs_bridge*]
+# (optional) Name of Integration Bridge used by Open vSwitch
+#
+# [*neutron_ca_certificates_file*]
+# (optional) Location of ca certificates file to use for
+# neutron client requests.
+#
+
+class manila::network::neutron (
+  $neutron_url                  = 'http://127.0.0.1:9696',
+  $neutron_url_timeout          = 30,
+  $neutron_admin_username       = 'neutron',
+  $neutron_admin_password       = undef,
+  $neutron_admin_tenant_name    = 'service',
+  $neutron_region_name          = undef,
+  $neutron_admin_auth_url       = 'http://localhost:5000/v2.0',
+  $neutron_api_insecure         = false,
+  $neutron_auth_strategy        = 'keystone',
+  $neutron_ovs_bridge           = 'br-int',
+  $neutron_ca_certificates_file = undef,
+) {
+
+  manila_config {
+    'DEFAULT/neutron_url':                  value => $neutron_url;
+    'DEFAULT/neutron_url_timeout':          value => $neutron_url_timeout;
+    'DEFAULT/neutron_admin_username':       value => $neutron_admin_username;
+    'DEFAULT/neutron_admin_password':       value => $neutron_admin_password;
+    'DEFAULT/neutron_admin_tenant_name':    value => $neutron_admin_tenant_name;
+    'DEFAULT/neutron_region_name':          value => $neutron_region_name;
+    'DEFAULT/neutron_admin_auth_url':       value => $neutron_admin_auth_url;
+    'DEFAULT/neutron_api_insecure':         value => $neutron_api_insecure;
+    'DEFAULT/neutron_auth_strategy':        value => $neutron_auth_strategy;
+    'DEFAULT/neutron_ovs_bridge':           value => $neutron_ovs_bridge;
+    'DEFAULT/neutron_ca_certificates_file': value => $neutron_ca_certificates_file;
+    }
+}

--- a/manila/manifests/params.pp
+++ b/manila/manifests/params.pp
@@ -1,0 +1,48 @@
+#
+class manila::params {
+
+  $manila_conf = '/etc/manila/manila.conf'
+  $manila_paste_api_ini = '/etc/manila/api-paste.ini'
+
+  if $::osfamily == 'Debian' {
+    $package_name       = 'manila-common'
+    $client_package     = 'python-manilaclient'
+    $api_package        = 'manila-api'
+    $api_service        = 'manila-api'
+    $scheduler_package  = 'manila-scheduler'
+    $scheduler_service  = 'manila-scheduler'
+    $share_package      = 'manila-share'
+    $share_service      = 'manila-share'
+    $db_sync_command    = 'manila-manage db sync'
+    $tgt_package_name   = 'tgt'
+    $tgt_service_name   = 'tgt'
+    $ceph_init_override = '/etc/init/manila-share.override'
+    $iscsi_helper       = 'tgtadm'
+    $lio_package_name   = 'targetcli'
+
+  } elsif($::osfamily == 'RedHat') {
+
+    $package_name       = 'openstack-manila'
+    $client_package     = 'python-manilaclient'
+    $api_package        = false
+    $api_service        = 'openstack-manila-api'
+    $scheduler_package  = false
+    $scheduler_service  = 'openstack-manila-scheduler'
+    $share_package      = 'openstack-manila-share'
+    $share_service      = 'openstack-manila-share'
+    $db_sync_command    = 'manila-manage db sync'
+    $tgt_package_name   = 'scsi-target-utils'
+    $tgt_service_name   = 'tgtd'
+    $ceph_init_override = '/etc/sysconfig/openstack-manila-share'
+    $lio_package_name   = 'targetcli'
+
+    if $::operatingsystem == 'RedHat' and $::operatingsystemmajrelease >= 7 {
+      $iscsi_helper = 'lioadm'
+    } else {
+      $iscsi_helper = 'tgtadm'
+    }
+
+  } else {
+    fail("unsuported osfamily ${::osfamily}, currently Debian and Redhat are the only supported platforms")
+  }
+}

--- a/manila/manifests/qpid.pp
+++ b/manila/manifests/qpid.pp
@@ -1,0 +1,35 @@
+#
+# class for installing qpid server for manila
+#
+#
+class manila::qpid(
+  $enabled = true,
+  $user='guest',
+  $password='guest',
+  $file='/var/lib/qpidd/qpidd.sasldb',
+  $realm='OPENSTACK'
+) {
+
+  # only configure manila after the queue is up
+  Class['qpid::server'] -> Package<| title == 'manila' |>
+
+  if ($enabled) {
+    $service_ensure = 'running'
+
+    qpid_user { $user:
+      password => $password,
+      file     => $file,
+      realm    => $realm,
+      provider => 'saslpasswd2',
+      require  => Class['qpid::server'],
+    }
+
+  } else {
+    $service_ensure = 'stopped'
+  }
+
+  class { 'qpid::server':
+    service_ensure => $service_ensure
+  }
+
+}

--- a/manila/manifests/quota.pp
+++ b/manila/manifests/quota.pp
@@ -1,0 +1,34 @@
+# == Class: manila::quota
+#
+# Setup and configure Manila quotas.
+#
+# === Parameters
+#
+# [*quota_shares*]
+#   (optional) Number of shares allowed per project. Defaults to 10.
+#
+# [*quota_snapshots*]
+#   (optional) Number of share snapshots allowed per project. Defaults to 10.
+#
+# [*quota_gigabytes*]
+#   (optional) Number of share gigabytes (snapshots are also included)
+#   allowed per project. Defaults to 1000.
+#
+# [*quota_driver*]
+#   (optional) Default driver to use for quota checks.
+#   Defaults to 'manila.quota.DbQuotaDriver'.
+#
+class manila::quota (
+  $quota_shares = 10,
+  $quota_snapshots = 10,
+  $quota_gigabytes = 1000,
+  $quota_driver = 'manila.quota.DbQuotaDriver'
+) {
+
+  manila_config {
+    'DEFAULT/quota_shares':    value => $quota_shares;
+    'DEFAULT/quota_snapshots': value => $quota_snapshots;
+    'DEFAULT/quota_gigabytes': value => $quota_gigabytes;
+    'DEFAULT/quota_driver':    value => $quota_driver;
+  }
+}

--- a/manila/manifests/rabbitmq.pp
+++ b/manila/manifests/rabbitmq.pp
@@ -1,0 +1,81 @@
+# == Class: manila::rabbitmq
+#
+# Installs and manages rabbitmq server for manila
+#
+# == Parameters:
+#
+# [*userid*]
+#   (optional) The username to use when connecting to Rabbit
+#   Defaults to 'guest'
+#
+# [*password*]
+#   (optional) The password to use when connecting to Rabbit
+#   Defaults to 'guest'
+#
+# [*port*]
+#   (optional) The port to use when connecting to Rabbit
+#   Defaults to '5672'
+#
+# [*virtual_host*]
+#   (optional) The virtual host to use when connecting to Rabbit
+#   Defaults to '/'
+#
+# [*enabled*]
+#   (optional) Whether to enable the Rabbit service
+#   Defaults to false
+#
+# [*rabbitmq_class*]
+#   (optional) The rabbitmq puppet class to depend on,
+#   which is dependent on the puppet-rabbitmq version.
+#   Use the default for 1.x, use 'rabbitmq' for 3.x
+#   Defaults to 'rabbitmq::server'
+#
+class manila::rabbitmq(
+  $userid         = 'guest',
+  $password       = 'guest',
+  $port           = '5672',
+  $virtual_host   = '/',
+  $enabled        = true,
+  $rabbitmq_class = 'rabbitmq::server',
+) {
+
+  # only configure manila after the queue is up
+  Class[$rabbitmq_class] -> Anchor<| title == 'manila-start' |>
+
+  if ($enabled) {
+    if $userid == 'guest' {
+      $delete_guest_user = false
+    } else {
+      $delete_guest_user = true
+      rabbitmq_user { $userid:
+        admin    => true,
+        password => $password,
+        provider => 'rabbitmqctl',
+        require  => Class[$rabbitmq_class],
+      }
+      # I need to figure out the appropriate permissions
+      rabbitmq_user_permissions { "${userid}@${virtual_host}":
+        configure_permission => '.*',
+        write_permission     => '.*',
+        read_permission      => '.*',
+        provider             => 'rabbitmqctl',
+      }->Anchor<| title == 'manila-start' |>
+    }
+    $service_ensure = 'running'
+  } else {
+    $service_ensure = 'stopped'
+  }
+
+  class { $rabbitmq_class:
+    service_ensure    => $service_ensure,
+    port              => $port,
+    delete_guest_user => $delete_guest_user,
+  }
+
+  if ($enabled) {
+    rabbitmq_vhost { $virtual_host:
+      provider => 'rabbitmqctl',
+      require  => Class[$rabbitmq_class],
+    }
+  }
+}

--- a/manila/manifests/scheduler.pp
+++ b/manila/manifests/scheduler.pp
@@ -1,0 +1,46 @@
+#
+class manila::scheduler (
+  $scheduler_driver = false,
+  $package_ensure   = 'present',
+  $enabled          = true,
+  $manage_service   = true
+) {
+
+  include manila::params
+
+  Manila_config<||> ~> Service['manila-scheduler']
+  Manila_api_paste_ini<||> ~> Service['manila-scheduler']
+  Exec<| title == 'manila-manage db_sync' |> ~> Service['manila-scheduler']
+
+  if $scheduler_driver {
+    manila_config {
+      'DEFAULT/scheduler_driver': value => $scheduler_driver;
+    }
+  }
+
+  if $::manila::params::scheduler_package {
+    Package['manila-scheduler'] -> Manila_config<||>
+    Package['manila-scheduler'] -> Manila_api_paste_ini<||>
+    Package['manila-scheduler'] -> Service['manila-scheduler']
+    package { 'manila-scheduler':
+      ensure => $package_ensure,
+      name   => $::manila::params::scheduler_package,
+    }
+  }
+
+  if $manage_service {
+    if $enabled {
+      $ensure = 'running'
+    } else {
+      $ensure = 'stopped'
+    }
+  }
+
+  service { 'manila-scheduler':
+    ensure    => $ensure,
+    name      => $::manila::params::scheduler_service,
+    enable    => $enabled,
+    hasstatus => true,
+    require   => Package['manila'],
+  }
+}

--- a/manila/manifests/service_instance.pp
+++ b/manila/manifests/service_instance.pp
@@ -1,0 +1,111 @@
+# ==define manila::service_instance
+#
+# ===Parameters
+# [*share_backend_name*]
+#   (required) Name of the backend in manila.conf that
+#   these settings will reside in
+#
+# [*service_image_name*]
+#   (optional) Name of image in glance, that will be used to create
+#    service instance.
+#   Defaults to: 'manila-service-image'
+#
+# [*service_instance_name_template*]
+#   (optional) Name of service instance.
+#   Defaults to: 'manila_service_instance_%s'
+#
+# [*service_instance_user*]
+#   (required) User in service instance.
+#
+# [*service_instance_password*]
+#   (required) Password to service instance user.
+#
+# [*manila_service_keypair_name*]
+#   (optional) Name of keypair that will be created and used
+#    for service instance.
+#   Defaults to: 'manila-service'
+#
+# [*path_to_public_key*]
+#   (optional) Path to hosts public key.
+#   Defaults to: '~/.ssh/id_rsa.pub'
+#
+# [*path_to_private_key*]
+#   (optional) Path to hosts private key.
+#   Defaults to: '~/.ssh/id_rsa'
+#
+# [*max_time_to_build_instance*]
+#   (optional) Maximum time to wait for creating service instance.
+#   Defaults to: 300
+#
+# [*service_instance_security_group*]
+#   (optional) Name of security group, that will be used for
+#    service instance creation.
+#   Defaults to: 'manila-service'
+#
+# [*service_instance_flavor_id*]
+#   (optional) ID of flavor, that will be used for service instance
+#    creation.
+#   Defaults to: 100
+#
+# [*service_network_name*]
+#   (optional) Name of manila service network.
+#   Defaults to: 'manila_service_network'
+#
+# [*service_network_cidr*]
+#   (optional) CIDR of manila service network.
+#   Defaults to: '10.254.0.0/16'
+#
+# [*service_network_division_mask*]
+#   (optional) This mask is used for dividing service network into
+#    subnets, IP capacity of subnet with this mask directly
+#    defines possible amount of created service VMs
+#    per tenant's subnet.
+#   Defaults to: 28
+#
+# [*interface_driver*]
+#   (optional) Vif driver.
+#   Defaults to: 'manila.network.linux.interface.OVSInterfaceDriver'
+#
+# [*connect_share_server_to_tenant_network*]
+#   (optional) Attach share server directly to smyhare network.
+#   Defaults to: false
+
+class manila::service_instance (
+  $share_backend_name                     = $name,
+  $service_image_name                     = 'manila-service-image',
+  $service_instance_name_template         = 'manila_service_instance_%s',
+  $service_instance_user                  = undef,
+  $service_instance_password              = undef,
+  $manila_service_keypair_name            = 'manila-service',
+  $path_to_public_key                     = '~/.ssh/id_rsa.pub',
+  $path_to_private_key                    = '~/.ssh/id_rsa',
+  $max_time_to_build_instance             = 300,
+  $service_instance_security_group        = 'manila-service',
+  $service_instance_flavor_id             = 100,
+  $service_network_name                   = 'manila_service_network',
+  $service_network_cidr                   = '10.254.0.0/16',
+  $service_network_division_mask          = 28,
+  $interface_driver = 'manila.network.linux.interface.OVSInterfaceDriver',
+  $connect_share_server_to_tenant_network = false,
+
+) {
+
+  manila_config {
+    "${name}/share_backend_name":                     value => $share_backend_name;
+    "${name}/service_image_name":                     value => $service_image_name;
+    "${name}/service_instance_name_template":         value => $service_instance_name_template;
+    "${name}/service_instance_user":                  value => $service_instance_user;
+    "${name}/service_instance_password":              value => $service_instance_password;
+    "${name}/manila_service_keypair_name":            value => $manila_service_keypair_name;
+    "${name}/path_to_public_key":                     value => $path_to_public_key;
+    "${name}/path_to_private_key":                    value => $path_to_private_key;
+    "${name}/max_time_to_build_instance":             value => $max_time_to_build_instance;
+    "${name}/service_instance_security_group":        value => $service_instance_security_group;
+    "${name}/service_instance_flavor_id":             value => $service_instance_flavor_id;
+    "${name}/service_network_name":                   value => $service_network_name;
+    "${name}/service_network_cidr":                   value => $service_network_cidr;
+    "${name}/service_network_division_mask":          value => $service_network_division_mask;
+    "${name}/interface_driver":                       value => $interface_driver;
+    "${name}/connect_share_server_to_tenant_network": value => $connect_share_server_to_tenant_network;
+  }
+}

--- a/manila/manifests/share.pp
+++ b/manila/manifests/share.pp
@@ -1,0 +1,40 @@
+# $share_name_template = share-%s
+class manila::share (
+  $package_ensure = 'present',
+  $enabled        = true,
+  $manage_service = true
+) {
+
+  include manila::params
+
+  Manila_config<||> ~> Service['manila-share']
+  Manila_api_paste_ini<||> ~> Service['manila-share']
+  Exec<| title == 'manila-manage db_sync' |> ~> Service['manila-share']
+
+  if $::manila::params::share_package {
+    Package['manila-share'] -> Manila_config<||>
+    Package['manila-share'] -> Manila_api_paste_ini<||>
+    Package['manila']        -> Package['manila-share']
+    Package['manila-share'] -> Service['manila-share']
+    package { 'manila-share':
+      ensure => $package_ensure,
+      name   => $::manila::params::share_package,
+    }
+  }
+
+  if $manage_service {
+    if $enabled {
+      $ensure = 'running'
+    } else {
+      $ensure = 'stopped'
+    }
+  }
+
+  service { 'manila-share':
+    ensure    => $ensure,
+    name      => $::manila::params::share_service,
+    enable    => $enabled,
+    hasstatus => true,
+    require   => Package['manila'],
+  }
+}

--- a/manila/manifests/share/generic.pp
+++ b/manila/manifests/share/generic.pp
@@ -1,0 +1,69 @@
+# == Class: manila::share::generic
+#
+# Configures Manila to use the generic share driver
+#
+# ===Parameters
+# [*smb_template_config_path*]
+#   (optional) Path to smb config.
+#   Defaults to: $state_path/smb.conf
+#
+# [*volume_name_template*]
+#   (optional) Volume name template.
+#   Defaults to: manila-share-%s
+#
+# [*volume_snapshot_name_template*]
+#   (optional) Volume snapshot name template.
+#   Defaults to: manila-snapshot-%s
+#
+# [*share_mount_path*]
+#   (optional) Parent path in service instance where shares will be mounted.
+#   Defaults to: /shares
+#
+# [*max_time_to_create_volume*]
+#   (optional) Maximum time to wait for creating cinder volume.
+#   Defaults to: 180
+#
+# [*max_time_to_attach*]
+#   (optional) Maximum time to wait for attaching cinder volume.
+#   Defaults to: 120
+#
+# [*service_instance_smb_config_path*]
+#   (optional) Path to smb config in service instance.
+#   Defaults to: $share_mount_path/smb.conf
+#
+# [*share_volume_fstype*]
+#   (optional) Filesystem type of the share volume.
+#   Choices: 'ext4', 'ext3'
+#   Defaults to: ext4
+#
+# [*share_helpers*]
+#   (optional) Specify list of share export helpers.
+#   Defaults to: ['CIFS=manila.share.drivers.generic.CIFSHelper',
+#                 'NFS=manila.share.drivers.generic.NFSHelper']
+#
+
+class manila::share::generic (
+  $smb_template_config_path         = '$state_path/smb.conf',
+  $volume_name_template             = 'manila-share-%s',
+  $volume_snapshot_name_template    = 'manila-snapshot-%s',
+  $share_mount_path                 = '/shares',
+  $max_time_to_create_volume        = 180,
+  $max_time_to_attach               = 120,
+  $service_instance_smb_config_path = '$share_mount_path/smb.conf',
+  $share_volume_fstype              = 'ext4',
+  $share_helpers = ['CIFS=manila.share.drivers.generic.CIFSHelper',
+                    'NFS=manila.share.drivers.generic.NFSHelper'],
+) {
+
+  manila::backend::generic { 'DEFAULT':
+    smb_template_config_path          => $smb_template_config_path,
+    volume_name_template              => $volume_name_template,
+    volume_snapshot_name_template     => $volume_snapshot_name_template,
+    share_mount_path                  => $share_mount_path,
+    max_time_to_create_volume         => $max_time_to_create_volume,
+    max_time_to_attach                => $max_time_to_attach,
+    service_instance_smb_config_path  => $service_instance_smb_config_path,
+    share_helpers                     => $share_helpers,
+    share_volume_fstype               => $share_volume_fstype,
+  }
+}

--- a/manila/manifests/share/glusterfs.pp
+++ b/manila/manifests/share/glusterfs.pp
@@ -1,0 +1,30 @@
+#
+# == Class: manila::share::glusterfs
+#
+# Configures Manila to use GlusterFS as a share driver
+#
+# === Parameters
+#
+# [*glusterfs_volumes_config*]
+#   (required) File with the list of Gluster volumes that can
+#   be used to create shares
+#
+# [*glusterfs_mount_point_base*]
+#   Base dir containing mount points for Gluster volumes.
+#
+# === Examples
+#
+# class { 'manila::share::glusterfs':
+#   glusterfs_shares = ['192.168.1.1:/shares'],
+# }
+#
+class manila::share::glusterfs (
+  $glusterfs_volumes_config   = '/etc/manila/glusterfs_volumes',
+  $glusterfs_mount_point_base = '$state_path/mnt',
+) {
+
+  manila::backend::glusterfs { 'DEFAULT':
+    glusterfs_volumes_config   => $glusterfs_volumes_config,
+    glusterfs_mount_point_base => $glusterfs_mount_point_base,
+  }
+}

--- a/manila/manifests/share/netapp.pp
+++ b/manila/manifests/share/netapp.pp
@@ -1,0 +1,78 @@
+# == Class: manila::share::netapp
+#
+# Configures Manila to use the NetApp share driver
+#
+# === Parameters
+#
+# [*netapp_nas_transport_type*]
+#   (optional) The transport protocol used when communicating with ONTAPI on the
+#   storage system or proxy server. Valid values are http or https.
+#   Defaults to http
+#
+# [*netapp_nas_login*]
+#   (required) Administrative user account name used to access the storage
+#   system or proxy server.
+#
+# [*netapp_nas_password*]
+#   (required) Password for the administrative user account specified in the
+#   netapp_nas_login parameter.
+#
+# [*netapp_nas_server_hostname*]
+#   (required) The hostname (or IP address) for the storage system or proxy
+#   server.
+#
+# [*netapp_nas_volume_name_template*]
+#   (optional) NetApp volume name template.
+#
+# [*netapp_vserver_name_template*]
+#   (optional) Name template to use for new vserver.
+#
+# [*netapp_lif_name_template*]
+#   (optional) Lif name template
+#
+# [*netapp_aggregate_name_search_pattern*]
+#   (optional) Pattern for searching available aggregates
+#   for provisioning.
+#
+# [*netapp_root_volume_aggregate*]
+#   (optional) Name of aggregate to create root volume on.
+#
+# [*netapp_root_volume_name*]
+#   (optional) Root volume name.
+#
+# === Examples
+#  class { 'manila::share::netapp':
+#    netapp_login => 'clusterAdmin',
+#    netapp_password => 'password',
+#    netapp_server_hostname => 'netapp.mycorp.com',
+#    netapp_server_port => '443',
+#    netapp_transport_type => 'https',
+#    netapp_vserver => 'openstack-vserver',
+#  }
+#
+class manila::share::netapp (
+    $netapp_nas_transport_type = 'http',
+    $netapp_nas_login = 'admin',
+    $netapp_nas_password = undef,
+    $netapp_nas_server_hostname  = undef,
+    $netapp_nas_volume_name_template= 'share_%(share_id)s',
+    $netapp_vserver_name_template = 'os_%s',
+    $netapp_lif_name_template = 'os_%(net_allocation_id)s',
+    $netapp_aggregate_name_search_pattern  = '(.*)',
+    $netapp_root_volume_aggregate = undef,
+    $netapp_root_volume_name = 'root',
+) {
+
+  manila::backend::netapp { 'DEFAULT':
+    netapp_nas_transport_type             => $netapp_nas_transport_type,
+    netapp_nas_login                      => $netapp_nas_login,
+    netapp_nas_password                   => $netapp_nas_password,
+    netapp_nas_server_hostname            => $netapp_nas_server_hostname,
+    netapp_nas_volume_name_template       => $netapp_nas_volume_name_template,
+    netapp_vserver_name_template          => $netapp_vserver_name_template,
+    netapp_lif_name_template              => $netapp_lif_name_template,
+    netapp_aggregate_name_search_pattern  => $netapp_aggregate_name_search_pattern,
+    netapp_root_volume_aggregate          => $netapp_root_volume_aggregate,
+    netapp_root_volume_name               => $netapp_root_volume_name,
+  }
+}

--- a/manila/manifests/type.pp
+++ b/manila/manifests/type.pp
@@ -1,0 +1,81 @@
+# ==Define: manila::type
+#
+# Creates manila type and assigns backends.
+#
+# === Parameters
+#
+# [*os_password*]
+#   (required) The keystone tenant:username password.
+#
+# [*set_key*]
+#   (optional) Must be used with set_value. Accepts a single string be used
+#     as the key in type_set
+#
+# [*set_value*]
+#   (optional) Accepts list of strings or singular string. A list of values
+#     passed to type_set
+#
+# [*os_tenant_name*]
+#   (optional) The keystone tenant name. Defaults to 'admin'.
+#
+# [*os_username*]
+#   (optional) The keystone user name. Defaults to 'admin.
+#
+# [*os_auth_url*]
+#   (optional) The keystone auth url. Defaults to 'http://127.0.0.1:5000/v2.0/'.
+#
+# [*os_region_name*]
+#   (optional) The keystone region name. Default is unset.
+#
+# Author: Andrew Woodward <awoodward@mirantis.com>
+
+define manila::type (
+  $os_password,
+  $set_key        = undef,
+  $set_value      = undef,
+  $os_tenant_name = 'admin',
+  $os_username    = 'admin',
+  $os_auth_url    = 'http://127.0.0.1:5000/v2.0/',
+  $os_region_name = undef,
+  ) {
+
+  $volume_name = $name
+
+# TODO: (xarses) This should be moved to a ruby provider so that among other
+#   reasons, the credential discovery magic can occur like in neutron.
+
+  $manila_env = [
+    "OS_TENANT_NAME=${os_tenant_name}",
+    "OS_USERNAME=${os_username}",
+    "OS_PASSWORD=${os_password}",
+    "OS_AUTH_URL=${os_auth_url}",
+  ]
+
+  if $os_region_name {
+    $region_env = ["OS_REGION_NAME=${os_region_name}"]
+  }
+  else {
+    $region_env = []
+  }
+
+  exec {"manila type-create ${volume_name}":
+    command     => "manila type-create ${volume_name}",
+    unless      => "manila type-list | grep ${volume_name}",
+    environment => concat($manila_env, $region_env),
+    require     => Package['python-manilaclient'],
+    path        => ['/usr/bin', '/bin'],
+  }
+
+  if ($set_value and $set_key) {
+    Exec["manila type-create ${volume_name}"] ->
+    manila::type_set { $set_value:
+      type            => $volume_name,
+      key             => $set_key,
+      os_password     => $os_password,
+      os_tenant_name  => $os_tenant_name,
+      os_username     => $os_username,
+      os_auth_url     => $os_auth_url,
+      os_region_name  => $os_region_name,
+    }
+  }
+}

--- a/manila/manifests/type_set.pp
+++ b/manila/manifests/type_set.pp
@@ -1,0 +1,65 @@
+# ==Define: manila::type_set
+#
+# Assigns keys after the share type is set.
+#
+# === Parameters
+#
+# [*os_password*]
+#   (required) The keystone tenant:username password.
+#
+# [*type*]
+#   (required) Accepts single name of type to set.
+#
+# [*key*]
+#   (required) the key name that we are setting the value for.
+#
+# [*os_tenant_name*]
+#   (optional) The keystone tenant name. Defaults to 'admin'.
+#
+# [*os_username*]
+#   (optional) The keystone user name. Defaults to 'admin.
+#
+# [*os_auth_url*]
+#   (optional) The keystone auth url. Defaults to 'http://127.0.0.1:5000/v2.0/'.
+#
+# [*os_region_name*]
+#   (optional) The keystone region name. Default is unset.
+#
+# Author: Andrew Woodward <awoodward@mirantis.com>
+
+
+define manila::type_set (
+  $type,
+  $key,
+  $os_password,
+  $os_tenant_name = 'admin',
+  $os_username    = 'admin',
+  $os_auth_url    = 'http://127.0.0.1:5000/v2.0/',
+  $os_region_name = undef,
+  ) {
+
+
+# TODO: (xarses) This should be moved to a ruby provider so that among other
+#   reasons, the credential discovery magic can occur like in neutron.
+
+  $manila_env = [
+    "OS_TENANT_NAME=${os_tenant_name}",
+    "OS_USERNAME=${os_username}",
+    "OS_PASSWORD=${os_password}",
+    "OS_AUTH_URL=${os_auth_url}",
+  ]
+
+  if $os_region_name {
+    $region_env = ["OS_REGION_NAME=${os_region_name}"]
+  }
+  else {
+    $region_env = []
+  }
+
+  exec {"manila type-key ${type} set ${key}=${name}":
+    path        => ['/usr/bin', '/bin'],
+    command     => "manila type-key ${type} set ${key}=${name}",
+    environment => concat($manila_env, $region_env),
+    require     => Package['python-manilaclient']
+  }
+}

--- a/manila/manifests/volume/cinder.pp
+++ b/manila/manifests/volume/cinder.pp
@@ -1,0 +1,65 @@
+# == Class: manila::cinder
+#
+# Setup and configure Cinder communication
+#
+# === Parameters
+#
+# [*cinder_catalog_info*]
+# (optional) Info to match when looking for cinder in the service
+# catalog. Format is : separated values of the form:
+# <service_type>:<service_name>:<endpoint_type>
+#
+# [*os_region_name*]
+# (optional) region name of this node
+#
+# [*cinder_ca_certificates_file*]
+# (optional) Location of ca certificates file to use for cinder
+# client requests.
+#
+# [*cinder_http_retries*]
+# (optional) Number of cinderclient retries on failed http calls
+#
+# [*cinder_api_insecure*]
+# (optional) Allow to perform insecure SSL requests to cinder
+#
+# [*cinder_cross_az_attach*]
+# (optional) Allow attach between instance and volume in different
+# availability zones.
+#
+# [*cinder_admin_username*]
+# (optional) Cinder admin username
+#
+# [*cinder_admin_password*]
+# (optional) Cinder admin password
+#
+# [*cinder_admin_tenant_name*]
+# (optional) Cinder admin tenant name
+#
+# [*cinder_admin_auth_url*]
+# (optional) Identity service url
+#
+
+class manila::volume::cinder (
+  $cinder_catalog_info = 'volume:cinder:publicURL',
+  $cinder_ca_certificates_file = undef,
+  $cinder_http_retries = 3,
+  $cinder_api_insecure = false,
+  $cinder_cross_az_attach = true,
+  $cinder_admin_username = 'cinder',
+  $cinder_admin_password = undef,
+  $cinder_admin_tenant_name = 'service',
+  $cinder_admin_auth_url = 'http://localhost:5000/v2.0',
+) {
+
+manila_config {
+  'DEFAULT/cinder_catalog_info':          value => $cinder_catalog_info;
+  'DEFAULT/cinder_ca_certificates_file':  value => $cinder_ca_certificates_file;
+  'DEFAULT/cinder_http_retries':          value => $cinder_http_retries;
+  'DEFAULT/cinder_api_insecure':          value => $cinder_api_insecure;
+  'DEFAULT/cinder_cross_az_attach':       value => $cinder_cross_az_attach;
+  'DEFAULT/cinder_admin_username':        value => $cinder_admin_username;
+  'DEFAULT/cinder_admin_password':        value => $cinder_admin_password;
+  'DEFAULT/cinder_admin_tenant_name':     value => $cinder_admin_tenant_name;
+  'DEFAULT/cinder_admin_auth_url':        value => $cinder_admin_auth_url;
+  }
+}

--- a/manila/metadata.json
+++ b/manila/metadata.json
@@ -1,0 +1,41 @@
+{
+  "name": "stackforge-manila",
+  "version": "5.0.0",
+  "author": "NetApp and StackForge Contributors",
+  "summary": "Puppet module for OpenStack Manila",
+  "license": "Apache License 2.0",
+  "source": "git://github.com/stackforge/puppet-manila.git",
+  "project_page": "https://launchpad.net/puppet-manila",
+  "issues_url": "https://bugs.launchpad.net/puppet-manila",
+  "requirements": [
+    {"name": "pe","version_requirement": "3.x"},
+    {"name": "puppet","version_requirement": "3.x"}
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": ["8"]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": ["20"]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": ["7"]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": ["14.04"]
+    }
+  ],
+  "description": "Installs and configures OpenStack Manila (Shared Filesystems).",
+  "dependencies": [
+    { "name": "dprince/qpid", "version_requirement": ">=1.0.0 <2.0.0" },
+    { "name": "puppetlabs/inifile", "version_requirement": ">=1.0.0 <2.0.0" },
+    { "name": "stackforge/keystone", "version_requirement": ">=5.0.0 <6.0.0" },
+    { "name": "puppetlabs/rabbitmq", "version_requirement": ">=2.0.2 <4.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.0.0 <5.0.0" },
+    { "name": "stackforge/openstacklib", "version_requirement": ">=5.0.0" }
+  ]
+}

--- a/manila/spec/classes/manila_api_spec.rb
+++ b/manila/spec/classes/manila_api_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+
+describe 'manila::api' do
+
+  let :req_params do
+    {:keystone_password => 'foo'}
+  end
+  let :facts do
+    {:osfamily => 'Debian'}
+  end
+
+  describe 'with only required params' do
+    let :params do
+      req_params
+    end
+
+    it { should contain_service('manila-api').with(
+      'hasstatus' => true,
+      'ensure' => 'running'
+    )}
+
+    it 'should configure manila api correctly' do
+      should contain_manila_config('DEFAULT/auth_strategy').with(
+       :value => 'keystone'
+      )
+      should contain_manila_config('DEFAULT/osapi_share_listen').with(
+       :value => '0.0.0.0'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/service_protocol').with(
+        :value => 'http'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/service_host').with(
+        :value => 'localhost'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/service_port').with(
+        :value => '5000'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/auth_protocol').with(
+        :value => 'http'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/auth_host').with(
+        :value => 'localhost'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/auth_port').with(
+        :value => '35357'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/auth_admin_prefix').with(
+        :ensure => 'absent'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/admin_tenant_name').with(
+        :value => 'services'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/admin_user').with(
+        :value => 'manila'
+      )
+      should contain_manila_api_paste_ini('filter:authtoken/admin_password').with(
+        :value  => 'foo',
+        :secret => true
+      )
+
+      should contain_manila_api_paste_ini('filter:authtoken/auth_uri').with(
+        :value => 'http://localhost:5000/'
+      )
+
+      should_not contain_manila_config('DEFAULT/os_region_name')
+    end
+  end
+
+  describe 'with a custom region for nova' do
+    let :params do
+      req_params.merge({'os_region_name' => 'MyRegion'})
+    end
+    it 'should configure the region for nova' do
+      should contain_manila_config('DEFAULT/os_region_name').with(
+        :value => 'MyRegion'
+      )
+    end
+  end
+
+  describe 'with custom auth_uri' do
+    let :params do
+      req_params.merge({'keystone_auth_uri' => 'http://foo.bar:8080/v2.0/'})
+    end
+    it 'should configure manila auth_uri correctly' do
+      should contain_manila_api_paste_ini('filter:authtoken/auth_uri').with(
+        :value => 'http://foo.bar:8080/v2.0/'
+      )
+    end
+  end
+
+  describe 'with only required params' do
+    let :params do
+      req_params.merge({'bind_host' => '192.168.1.3'})
+    end
+    it 'should configure manila api correctly' do
+      should contain_manila_config('DEFAULT/osapi_share_listen').with(
+       :value => '192.168.1.3'
+      )
+    end
+  end
+
+  [ '/keystone', '/keystone/admin', '' ].each do |keystone_auth_admin_prefix|
+    describe "with keystone_auth_admin_prefix containing incorrect value #{keystone_auth_admin_prefix}" do
+      let :params do
+        {
+          :keystone_auth_admin_prefix => keystone_auth_admin_prefix,
+          :keystone_password    => 'dummy'
+        }
+      end
+
+      it { should contain_manila_api_paste_ini('filter:authtoken/auth_admin_prefix').with(
+        :value => keystone_auth_admin_prefix
+      )}
+    end
+  end
+
+  [
+    '/keystone/',
+    'keystone/',
+    'keystone',
+    '/keystone/admin/',
+    'keystone/admin/',
+    'keystone/admin'
+  ].each do |keystone_auth_admin_prefix|
+    describe "with keystone_auth_admin_prefix containing incorrect value #{keystone_auth_admin_prefix}" do
+      let :params do
+        {
+          :keystone_auth_admin_prefix => keystone_auth_admin_prefix,
+          :keystone_password    => 'dummy'
+        }
+      end
+
+      it { expect { should contain_manila_api_paste_ini('filter:authtoken/auth_admin_prefix') }.to \
+        raise_error(Puppet::Error, /validate_re\(\): "#{keystone_auth_admin_prefix}" does not match/) }
+    end
+  end
+
+  describe 'with enabled false' do
+    let :params do
+      req_params.merge({'enabled' => false})
+    end
+    it 'should stop the service' do
+      should contain_service('manila-api').with_ensure('stopped')
+    end
+    it 'should contain db_sync exec' do
+      should_not contain_exec('manila-manage db_sync')
+    end
+  end
+
+  describe 'with manage_service false' do
+    let :params do
+      req_params.merge({'manage_service' => false})
+    end
+    it 'should not change the state of the service' do
+      should contain_service('manila-api').without_ensure
+    end
+  end
+
+  describe 'with ratelimits' do
+    let :params do
+      req_params.merge({ :ratelimits => '(GET, "*", .*, 100, MINUTE);(POST, "*", .*, 200, MINUTE)' })
+    end
+
+    it { should contain_manila_api_paste_ini('filter:ratelimit/limits').with(
+      :value => '(GET, "*", .*, 100, MINUTE);(POST, "*", .*, 200, MINUTE)'
+    )}
+  end
+
+end

--- a/manila/spec/classes/manila_backends_spec.rb
+++ b/manila/spec/classes/manila_backends_spec.rb
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2014 eNovance SAS <licensing@enovance.com>
+#
+# Author: Emilien Macchi <emilien.macchi@enovance.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Unit tests for manila::backends class
+#
+
+require 'spec_helper'
+
+describe 'manila::backends' do
+
+  let :default_params do
+    {}
+  end
+
+  let :params do
+    {}
+  end
+
+  shared_examples_for 'manila backends' do
+
+    let :p do
+      default_params.merge(params)
+    end
+
+    context 'configure manila with default parameters' do
+      before :each do
+        params.merge!(
+         :enabled_share_backends => ['lowcost', 'regular', 'premium']
+        )
+      end
+
+      it 'configures manila.conf with default params' do
+        should contain_manila_config('DEFAULT/enabled_share_backends').with_value(p[:enabled_share_backends].join(','))
+      end
+    end
+
+  end
+
+  context 'on Debian platforms' do
+    let :facts do
+      { :osfamily => 'Debian' }
+    end
+
+    it_configures 'manila backends'
+  end
+
+  context 'on RedHat platforms' do
+    let :facts do
+      { :osfamily => 'RedHat' }
+    end
+
+    it_configures 'manila backends'
+  end
+
+end

--- a/manila/spec/classes/manila_client_spec.rb
+++ b/manila/spec/classes/manila_client_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'manila::client' do
+  it { should contain_package('python-manilaclient').with_ensure('present') }
+  let :facts do
+    {:osfamily => 'Debian'}
+  end
+  context 'with params' do
+    let :params do
+      {:package_ensure => 'latest'}
+    end
+    it { should contain_package('python-manilaclient').with_ensure('latest') }
+  end
+end

--- a/manila/spec/classes/manila_db_mysql_spec.rb
+++ b/manila/spec/classes/manila_db_mysql_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'manila::db::mysql' do
+
+  let :req_params do
+    {:password => 'pw',
+    }
+  end
+
+  let :facts do
+    {:osfamily => 'Debian'}
+  end
+
+  let :pre_condition do
+    'include mysql::server'
+  end
+
+  describe 'with only required params' do
+    let :params do
+      req_params
+    end
+    it { should contain_openstacklib__db__mysql('manila').with(
+      :user         => 'manila',
+      :password_hash => '*D821809F681A40A6E379B50D0463EFAE20BDD122',
+      :host         => '127.0.0.1',
+      :charset      => 'utf8'
+     ) }
+  end
+  describe "overriding allowed_hosts param to array" do
+    let :params do
+      {
+        :password       => 'manilapass',
+        :allowed_hosts  => ['127.0.0.1','%']
+      }
+    end
+
+  end
+  describe "overriding allowed_hosts param to string" do
+    let :params do
+      {
+        :password       => 'manilapass2',
+        :allowed_hosts  => '192.168.1.1'
+      }
+    end
+
+  end
+
+  describe "overriding allowed_hosts param equals to host param " do
+    let :params do
+      {
+        :password       => 'manilapass2',
+        :allowed_hosts  => '127.0.0.1'
+      }
+    end
+
+  end
+end

--- a/manila/spec/classes/manila_db_postgresql_spec.rb
+++ b/manila/spec/classes/manila_db_postgresql_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'manila::db::postgresql' do
+
+  let :req_params do
+    {:password => 'pw'}
+  end
+
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'RedHat',
+    }
+  end
+
+  describe 'with only required params' do
+    let :params do
+      req_params
+    end
+    it { should contain_postgresql__db('manila').with(
+      :user         => 'manila',
+      :password     => 'pw'
+     ) }
+  end
+
+end

--- a/manila/spec/classes/manila_db_sync_spec.rb
+++ b/manila/spec/classes/manila_db_sync_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'manila::db::sync' do
+
+  let :facts do
+    {:osfamily => 'Debian'}
+  end
+  it { should contain_exec('manila-manage db_sync').with(
+    :command     => 'manila-manage db sync',
+    :path        => '/usr/bin',
+    :user        => 'manila',
+    :refreshonly => true,
+    :logoutput   => 'on_failure'
+  ) }
+
+end

--- a/manila/spec/classes/manila_keystone_auth_spec.rb
+++ b/manila/spec/classes/manila_keystone_auth_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe 'manila::keystone::auth' do
+
+  let :req_params do
+    {:password => 'pw'}
+  end
+
+  describe 'with only required params' do
+
+    let :params do
+      req_params
+    end
+
+    it 'should contain auth info' do
+
+      should contain_keystone_user('manila').with(
+        :ensure   => 'present',
+        :password => 'pw',
+        :email    => 'manila@localhost',
+        :tenant   => 'services'
+      )
+      should contain_keystone_user_role('manila@services').with(
+        :ensure  => 'present',
+        :roles   => 'admin'
+      )
+      should contain_keystone_service('manila').with(
+        :ensure      => 'present',
+        :type        => 'share',
+        :description => 'Manila Service'
+      )
+
+    end
+    it { should contain_keystone_endpoint('RegionOne/manila').with(
+      :ensure       => 'present',
+      :public_url   => 'http://127.0.0.1:8786/v1/%(tenant_id)s',
+      :admin_url    => 'http://127.0.0.1:8786/v1/%(tenant_id)s',
+      :internal_url => 'http://127.0.0.1:8786/v1/%(tenant_id)s'
+    ) }
+
+  end
+
+  context 'when overriding endpoint params' do
+     let :params do
+       req_params.merge(
+        :public_address    => '10.0.42.1',
+        :admin_address     => '10.0.42.2',
+        :internal_address  => '10.0.42.3',
+        :region            => 'RegionThree',
+        :port              => '4242',
+        :admin_protocol    => 'https',
+        :internal_protocol => 'https',
+        :public_protocol   => 'https',
+        :share_version     => 'v42'
+      )
+     end
+
+    it { should contain_keystone_endpoint('RegionThree/manila').with(
+      :ensure       => 'present',
+      :public_url   => 'https://10.0.42.1:4242/v42/%(tenant_id)s',
+      :admin_url    => 'https://10.0.42.2:4242/v42/%(tenant_id)s',
+      :internal_url => 'https://10.0.42.3:4242/v42/%(tenant_id)s'
+    )}
+
+  end
+
+
+  describe 'when endpoint should not be configured' do
+    let :params do
+      req_params.merge(
+        :configure_endpoint => false
+      )
+    end
+    it { should_not contain_keystone_endpoint('RegionOne/manila') }
+  end
+
+end

--- a/manila/spec/classes/manila_params_spec.rb
+++ b/manila/spec/classes/manila_params_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'manila::params' do
+
+  let :facts do
+    {:osfamily => 'Debian'}
+  end
+  it 'should compile' do
+    subject
+  end
+
+end

--- a/manila/spec/classes/manila_qpid_spec.rb
+++ b/manila/spec/classes/manila_qpid_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'manila::qpid' do
+
+  let :facts do
+    {:puppetversion => '2.7',
+     :osfamily => 'RedHat'}
+  end
+
+  describe 'with defaults' do
+
+    it 'should contain all of the default resources' do
+
+      should contain_class('qpid::server').with(
+        :service_ensure    => 'running',
+        :port              => '5672'
+      )
+
+    end
+
+    it 'should contain user' do
+
+      should contain_qpid_user('guest').with(
+        :password => 'guest',
+        :file     => '/var/lib/qpidd/qpidd.sasldb',
+        :realm    => 'OPENSTACK',
+        :provider => 'saslpasswd2'
+      )
+
+    end
+
+  end
+
+  describe 'when disabled' do
+    let :params do
+      {
+        :enabled  => false
+      }
+    end
+
+    it 'should be disabled' do
+
+      should_not contain_qpid_user('guest')
+      should contain_class('qpid::server').with(
+        :service_ensure    => 'stopped'
+      )
+
+    end
+  end
+
+end

--- a/manila/spec/classes/manila_quota_spec.rb
+++ b/manila/spec/classes/manila_quota_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'manila::quota' do
+
+  describe 'with default parameters' do
+    it 'contains default values' do
+      should contain_manila_config('DEFAULT/quota_shares').with(
+        :value => 10)
+      should contain_manila_config('DEFAULT/quota_snapshots').with(
+        :value => 10)
+      should contain_manila_config('DEFAULT/quota_gigabytes').with(
+        :value => 1000)
+      should contain_manila_config('DEFAULT/quota_driver').with(
+        :value => 'manila.quota.DbQuotaDriver')
+    end
+  end
+
+  describe 'with overridden parameters' do
+    let :params do
+      { :quota_shares => 1000,
+        :quota_snapshots => 1000,
+        :quota_gigabytes => 100000 }
+    end
+    it 'contains overrided values' do
+      should contain_manila_config('DEFAULT/quota_shares').with(
+        :value => 1000)
+      should contain_manila_config('DEFAULT/quota_snapshots').with(
+        :value => 1000)
+      should contain_manila_config('DEFAULT/quota_gigabytes').with(
+        :value => 100000)
+      should contain_manila_config('DEFAULT/quota_driver').with(
+        :value => 'manila.quota.DbQuotaDriver')
+    end
+  end
+end

--- a/manila/spec/classes/manila_rabbitmq_spec.rb
+++ b/manila/spec/classes/manila_rabbitmq_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe 'manila::rabbitmq' do
+
+  let :facts do
+    { :puppetversion => '2.7',
+      :osfamily      => 'Debian',
+    }
+  end
+
+  describe 'with defaults' do
+
+    it 'should contain all of the default resources' do
+
+      should contain_class('rabbitmq::server').with(
+        :service_ensure    => 'running',
+        :port              => '5672',
+        :delete_guest_user => false
+      )
+
+      should contain_rabbitmq_vhost('/').with(
+        :provider => 'rabbitmqctl'
+      )
+    end
+
+  end
+
+  describe 'when a rabbitmq user is specified' do
+
+    let :params do
+      {
+        :userid   => 'dan',
+        :password => 'pass'
+      }
+    end
+
+    it 'should contain user and permissions' do
+
+      should contain_rabbitmq_user('dan').with(
+        :admin    => true,
+        :password => 'pass',
+        :provider => 'rabbitmqctl'
+      )
+
+      should contain_rabbitmq_user_permissions('dan@/').with(
+        :configure_permission => '.*',
+        :write_permission     => '.*',
+        :read_permission      => '.*',
+        :provider             => 'rabbitmqctl'
+      )
+
+    end
+
+  end
+
+  describe 'when disabled' do
+    let :params do
+      {
+        :userid   => 'dan',
+        :password => 'pass',
+        :enabled  => false
+      }
+    end
+
+    it 'should be disabled' do
+
+      should_not contain_rabbitmq_user('dan')
+      should_not contain_rabbitmq_user_permissions('dan@/')
+      should contain_class('rabbitmq::server').with(
+        :service_ensure    => 'stopped',
+        :port              => '5672',
+        :delete_guest_user => false
+      )
+
+      should_not contain_rabbitmq_vhost('/')
+
+    end
+  end
+
+
+end

--- a/manila/spec/classes/manila_scheduler_spec.rb
+++ b/manila/spec/classes/manila_scheduler_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe 'manila::scheduler' do
+
+  describe 'on debian platforms' do
+
+    let :facts do
+      { :osfamily => 'Debian' }
+    end
+
+    describe 'with default parameters' do
+
+      it { should contain_class('manila::params') }
+
+      it { should contain_package('manila-scheduler').with(
+        :name      => 'manila-scheduler',
+        :ensure    => 'present',
+        :before    => 'Service[manila-scheduler]'
+      ) }
+
+      it { should contain_service('manila-scheduler').with(
+        :name      => 'manila-scheduler',
+        :enable    => true,
+        :ensure    => 'running',
+        :require   => 'Package[manila]',
+        :hasstatus => true
+      ) }
+    end
+
+    describe 'with parameters' do
+
+      let :params do
+        { :scheduler_driver => 'manila.scheduler.filter_scheduler.FilterScheduler',
+          :package_ensure   => 'present'
+        }
+      end
+
+      it { should contain_manila_config('DEFAULT/scheduler_driver').with_value('manila.scheduler.filter_scheduler.FilterScheduler') }
+      it { should contain_package('manila-scheduler').with_ensure('present') }
+    end
+
+    describe 'with manage_service false' do
+      let :params do
+        { 'manage_service' => false
+        }
+      end
+      it 'should not change the state of the service' do
+        should contain_service('manila-scheduler').without_ensure
+      end
+    end
+  end
+
+
+  describe 'on rhel platforms' do
+
+    let :facts do
+      { :osfamily => 'RedHat' }
+    end
+
+    describe 'with default parameters' do
+
+      it { should contain_class('manila::params') }
+
+      it { should contain_service('manila-scheduler').with(
+        :name    => 'openstack-manila-scheduler',
+        :enable  => true,
+        :ensure  => 'running',
+        :require => 'Package[manila]'
+      ) }
+    end
+
+    describe 'with parameters' do
+
+      let :params do
+        { :scheduler_driver => 'manila.scheduler.filter_scheduler.FilterScheduler' }
+      end
+
+      it { should contain_manila_config('DEFAULT/scheduler_driver').with_value('manila.scheduler.filter_scheduler.FilterScheduler') }
+    end
+  end
+end

--- a/manila/spec/classes/manila_share_generic_spec.rb
+++ b/manila/spec/classes/manila_share_generic_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'manila::share::generic' do
+
+  let :params do
+    {
+      :smb_template_config_path         => '$state_path/smb.conf',
+      :volume_name_template             => 'manila-share-%s',
+      :volume_snapshot_name_template    => 'manila-snapshot-%s',
+      :share_mount_path                 => '/shares',
+      :max_time_to_create_volume        => 180,
+      :max_time_to_attach               => 120,
+      :service_instance_smb_config_path => '$share_mount_path/smb.conf',
+      :share_helpers                    => ['CIFS=manila.share.drivers.generic.CIFSHelper',
+                                            'NFS=manila.share.drivers.generic.NFSHelper'],
+      :share_volume_fstype              => 'ext4',
+    }
+  end
+
+  describe 'generic share driver' do
+    it 'configures generic share driver' do
+      should contain_manila_config('DEFAULT/share_driver').with_value(
+        'manila.share.drivers.generic.GenericShareDriver')
+      params.each_pair do |config,value|
+        should contain_manila_config("DEFAULT/#{config}").with_value( value )
+      end
+    end
+  end
+end

--- a/manila/spec/classes/manila_share_glusterfs_spec.rb
+++ b/manila/spec/classes/manila_share_glusterfs_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'manila::share::glusterfs' do
+
+  shared_examples_for 'glusterfs share driver' do
+    let :params do
+      {
+        :glusterfs_volumes_config    => '/etc/manila/glusterfs_volumes',
+        :glusterfs_mount_point_base  => '$state_path/mnt',
+      }
+    end
+
+    it 'configures glusterfs share driver' do
+      should contain_manila_config('DEFAULT/share_driver').with_value(
+        'manila.share.drivers.glusterfs.GlusterfsShareDriver')
+      should contain_manila_config('DEFAULT/glusterfs_volumes_config').with_value(
+        '/etc/manila/glusterfs_volumes')
+      should contain_manila_config('DEFAULT/glusterfs_mount_point_base').with_value(
+        '$state_path/mnt')
+    end
+
+  end
+
+  context 'on Debian platforms' do
+    let :facts do
+      { :osfamily => 'Debian' }
+    end
+
+    it_configures 'glusterfs share driver'
+  end
+
+  context 'on RedHat platforms' do
+    let :facts do
+      { :osfamily => 'RedHat' }
+    end
+
+    it_configures 'glusterfs share driver'
+  end
+
+end

--- a/manila/spec/classes/manila_share_netapp_spec.rb
+++ b/manila/spec/classes/manila_share_netapp_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'manila::share::netapp' do
+
+  let :params do
+    {
+      :netapp_nas_login             => 'netapp',
+      :netapp_nas_password          => 'password',
+      :netapp_nas_server_hostname   => '127.0.0.2',
+      :netapp_root_volume_aggregate => 'aggr1',
+    }
+  end
+
+  let :default_params do
+    {
+      :netapp_nas_transport_type            => 'http',
+      :netapp_nas_volume_name_template      => 'share_%(share_id)s',
+      :netapp_vserver_name_template         => 'os_%s',
+      :netapp_lif_name_template             => 'os_%(net_allocation_id)s',
+      :netapp_aggregate_name_search_pattern => '(.*)',
+      :netapp_root_volume_name              => 'root',
+    }
+  end
+
+
+  shared_examples_for 'netapp share driver' do
+    let :params_hash do
+      default_params.merge(params)
+    end
+
+    it 'configures netapp share driver' do
+      should contain_manila_config('DEFAULT/share_driver').with_value(
+        'manila.share.drivers.netapp.cluster_mode.NetAppClusteredShareDriver')
+      params_hash.each_pair do |config,value|
+        should contain_manila_config("DEFAULT/#{config}").with_value( value )
+      end
+    end
+
+    it 'marks netapp_password as secret' do
+      should contain_manila_config('DEFAULT/netapp_nas_password').with_secret( true )
+    end
+  end
+
+
+  context 'with default parameters' do
+    before do
+      params = {}
+    end
+
+    it_configures 'netapp share driver'
+  end
+
+  context 'with provided parameters' do
+    it_configures 'netapp share driver'
+  end
+end

--- a/manila/spec/classes/manila_share_spec.rb
+++ b/manila/spec/classes/manila_share_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'manila::share' do
+
+  shared_examples_for 'manila-share' do
+    let :pre_condition do
+      'class { "manila": rabbit_password => "fpp", sql_connection => "mysql://a:b@c/d" }'
+    end
+
+    it { should contain_package('manila-share').with(
+      :name   => platform_params[:package_name],
+      :ensure => 'present'
+    ) }
+    it { should contain_service('manila-share').with(
+      'hasstatus' => true
+    )}
+
+    describe 'with manage_service false' do
+      let :params do
+        { 'manage_service' => false }
+      end
+      it 'should not change the state of the service' do
+        should contain_service('manila-share').without_ensure
+      end
+    end
+  end
+
+  context 'on Debian platforms' do
+    let :facts do
+      { :osfamily => 'Debian' }
+    end
+
+    let :platform_params do
+      { :package_name => 'manila-share' }
+    end
+
+    it_configures 'manila-share'
+  end
+
+  context 'on RedHat platforms' do
+    let :facts do
+      { :osfamily => 'RedHat' }
+    end
+
+    let :platform_params do
+      { :package_name => 'openstack-manila-share' }
+    end
+
+    it_configures 'manila-share'
+  end
+
+end

--- a/manila/spec/classes/manila_spec.rb
+++ b/manila/spec/classes/manila_spec.rb
@@ -1,0 +1,347 @@
+require 'spec_helper'
+describe 'manila' do
+  let :req_params do
+    {:rabbit_password => 'guest', :sql_connection => 'mysql://user:password@host/database'}
+  end
+
+  let :facts do
+    {:osfamily => 'Debian'}
+  end
+
+  describe 'with only required params' do
+    let :params do
+      req_params
+    end
+
+    it { should contain_class('manila::params') }
+    it { should contain_class('mysql::bindings::python') }
+
+    it 'should contain default config' do
+      should contain_manila_config('DEFAULT/sql_idle_timeout').with(
+        :value => '3600'
+      )
+      should contain_manila_config('DEFAULT/rpc_backend').with(
+        :value => 'manila.openstack.common.rpc.impl_kombu'
+      )
+      should contain_manila_config('DEFAULT/control_exchange').with(
+        :value => 'openstack'
+      )
+      should contain_manila_config('DEFAULT/rabbit_password').with(
+        :value => 'guest',
+        :secret => true
+      )
+      should contain_manila_config('DEFAULT/rabbit_host').with(
+        :value => '127.0.0.1'
+      )
+      should contain_manila_config('DEFAULT/rabbit_port').with(
+        :value => '5672'
+      )
+      should contain_manila_config('DEFAULT/rabbit_hosts').with(
+        :value => '127.0.0.1:5672'
+      )
+      should contain_manila_config('DEFAULT/rabbit_ha_queues').with(
+        :value => false
+      )
+      should contain_manila_config('DEFAULT/rabbit_virtual_host').with(
+        :value => '/'
+      )
+      should contain_manila_config('DEFAULT/rabbit_userid').with(
+        :value => 'guest'
+      )
+      should contain_manila_config('DEFAULT/sql_connection').with(
+        :value  => 'mysql://user:password@host/database',
+        :secret => true
+      )
+      should contain_manila_config('DEFAULT/verbose').with(
+        :value => false
+      )
+      should contain_manila_config('DEFAULT/debug').with(
+        :value => false
+      )
+      should contain_manila_config('DEFAULT/storage_availability_zone').with(
+        :value => 'nova'
+      )
+      should contain_manila_config('DEFAULT/api_paste_config').with(
+        :value => '/etc/manila/api-paste.ini'
+      )
+      should contain_manila_config('DEFAULT/rootwrap_config').with(
+        :value => '/etc/manila/rootwrap.conf'
+      )
+      should contain_manila_config('DEFAULT/log_dir').with(:value => '/var/log/manila')
+    end
+
+    it { should contain_file('/etc/manila/manila.conf').with(
+      :owner   => 'manila',
+      :group   => 'manila',
+      :mode    => '0600',
+      :require => 'Package[manila]'
+    ) }
+
+    it { should contain_file('/etc/manila/api-paste.ini').with(
+      :owner   => 'manila',
+      :group   => 'manila',
+      :mode    => '0600',
+      :require => 'Package[manila]'
+    ) }
+
+  end
+  describe 'with modified rabbit_hosts' do
+    let :params do
+      req_params.merge({'rabbit_hosts' => ['rabbit1:5672', 'rabbit2:5672']})
+    end
+
+    it 'should contain many' do
+      should_not contain_manila_config('DEFAULT/rabbit_host')
+      should_not contain_manila_config('DEFAULT/rabbit_port')
+      should contain_manila_config('DEFAULT/rabbit_hosts').with(
+        :value => 'rabbit1:5672,rabbit2:5672'
+      )
+      should contain_manila_config('DEFAULT/rabbit_ha_queues').with(
+        :value => true
+      )
+    end
+  end
+
+  describe 'with a single rabbit_hosts entry' do
+    let :params do
+      req_params.merge({'rabbit_hosts' => ['rabbit1:5672']})
+    end
+
+    it 'should contain many' do
+      should_not contain_manila_config('DEFAULT/rabbit_host')
+      should_not contain_manila_config('DEFAULT/rabbit_port')
+      should contain_manila_config('DEFAULT/rabbit_hosts').with(
+        :value => 'rabbit1:5672'
+      )
+      should contain_manila_config('DEFAULT/rabbit_ha_queues').with(
+        :value => true
+      )
+    end
+  end
+
+  describe 'with qpid rpc supplied' do
+
+    let :params do
+      {
+        :sql_connection      => 'mysql://user:password@host/database',
+        :qpid_password       => 'guest',
+        :rpc_backend         => 'manila.openstack.common.rpc.impl_qpid'
+      }
+    end
+
+    it { should contain_manila_config('DEFAULT/sql_connection').with_value('mysql://user:password@host/database') }
+    it { should contain_manila_config('DEFAULT/rpc_backend').with_value('manila.openstack.common.rpc.impl_qpid') }
+    it { should contain_manila_config('DEFAULT/qpid_hostname').with_value('localhost') }
+    it { should contain_manila_config('DEFAULT/qpid_port').with_value('5672') }
+    it { should contain_manila_config('DEFAULT/qpid_username').with_value('guest') }
+    it { should contain_manila_config('DEFAULT/qpid_password').with_value('guest').with_secret(true) }
+    it { should contain_manila_config('DEFAULT/qpid_reconnect').with_value(true) }
+    it { should contain_manila_config('DEFAULT/qpid_reconnect_timeout').with_value('0') }
+    it { should contain_manila_config('DEFAULT/qpid_reconnect_limit').with_value('0') }
+    it { should contain_manila_config('DEFAULT/qpid_reconnect_interval_min').with_value('0') }
+    it { should contain_manila_config('DEFAULT/qpid_reconnect_interval_max').with_value('0') }
+    it { should contain_manila_config('DEFAULT/qpid_reconnect_interval').with_value('0') }
+    it { should contain_manila_config('DEFAULT/qpid_heartbeat').with_value('60') }
+    it { should contain_manila_config('DEFAULT/qpid_protocol').with_value('tcp') }
+    it { should contain_manila_config('DEFAULT/qpid_tcp_nodelay').with_value(true) }
+  end
+
+  describe 'with qpid rpc and no qpid_sasl_mechanisms' do
+    let :params do
+      {
+        :sql_connection       => 'mysql://user:password@host/database',
+        :qpid_password        => 'guest',
+        :rpc_backend          => 'manila.openstack.common.rpc.impl_qpid'
+      }
+    end
+
+    it { should contain_manila_config('DEFAULT/qpid_sasl_mechanisms').with_ensure('absent') }
+  end
+
+  describe 'with qpid rpc and qpid_sasl_mechanisms string' do
+    let :params do
+      {
+        :sql_connection       => 'mysql://user:password@host/database',
+        :qpid_password        => 'guest',
+        :qpid_sasl_mechanisms => 'PLAIN',
+        :rpc_backend          => 'manila.openstack.common.rpc.impl_qpid'
+      }
+    end
+
+    it { should contain_manila_config('DEFAULT/qpid_sasl_mechanisms').with_value('PLAIN') }
+  end
+
+  describe 'with qpid rpc and qpid_sasl_mechanisms array' do
+    let :params do
+      {
+        :sql_connection       => 'mysql://user:password@host/database',
+        :qpid_password        => 'guest',
+        :qpid_sasl_mechanisms => [ 'DIGEST-MD5', 'GSSAPI', 'PLAIN' ],
+        :rpc_backend          => 'manila.openstack.common.rpc.impl_qpid'
+      }
+    end
+
+    it { should contain_manila_config('DEFAULT/qpid_sasl_mechanisms').with_value('DIGEST-MD5 GSSAPI PLAIN') }
+  end
+
+  describe 'with SSL enabled' do
+    let :params do
+      req_params.merge!({
+        :rabbit_use_ssl     => true,
+        :kombu_ssl_ca_certs => '/path/to/ssl/ca/certs',
+        :kombu_ssl_certfile => '/path/to/ssl/cert/file',
+        :kombu_ssl_keyfile  => '/path/to/ssl/keyfile',
+        :kombu_ssl_version  => 'SSLv3'
+      })
+    end
+
+    it do
+      should contain_manila_config('DEFAULT/rabbit_use_ssl').with_value('true')
+      should contain_manila_config('DEFAULT/kombu_ssl_ca_certs').with_value('/path/to/ssl/ca/certs')
+      should contain_manila_config('DEFAULT/kombu_ssl_certfile').with_value('/path/to/ssl/cert/file')
+      should contain_manila_config('DEFAULT/kombu_ssl_keyfile').with_value('/path/to/ssl/keyfile')
+      should contain_manila_config('DEFAULT/kombu_ssl_version').with_value('SSLv3')
+    end
+  end
+
+  describe 'with SSL disabled' do
+    let :params do
+      req_params.merge!({
+        :rabbit_use_ssl     => false,
+        :kombu_ssl_ca_certs => 'undef',
+        :kombu_ssl_certfile => 'undef',
+        :kombu_ssl_keyfile  => 'undef',
+        :kombu_ssl_version  => 'SSLv3'
+      })
+    end
+
+    it do
+      should contain_manila_config('DEFAULT/rabbit_use_ssl').with_value('false')
+      should contain_manila_config('DEFAULT/kombu_ssl_ca_certs').with_ensure('absent')
+      should contain_manila_config('DEFAULT/kombu_ssl_certfile').with_ensure('absent')
+      should contain_manila_config('DEFAULT/kombu_ssl_keyfile').with_ensure('absent')
+      should contain_manila_config('DEFAULT/kombu_ssl_version').with_ensure('absent')
+    end
+  end
+
+  describe 'with syslog disabled' do
+    let :params do
+      req_params
+    end
+
+    it { should contain_manila_config('DEFAULT/use_syslog').with_value(false) }
+  end
+
+  describe 'with syslog enabled' do
+    let :params do
+      req_params.merge({
+        :use_syslog   => 'true',
+      })
+    end
+
+    it { should contain_manila_config('DEFAULT/use_syslog').with_value(true) }
+    it { should contain_manila_config('DEFAULT/syslog_log_facility').with_value('LOG_USER') }
+  end
+
+  describe 'with syslog enabled and custom settings' do
+    let :params do
+      req_params.merge({
+        :use_syslog   => 'true',
+        :log_facility => 'LOG_LOCAL0'
+     })
+    end
+
+    it { should contain_manila_config('DEFAULT/use_syslog').with_value(true) }
+    it { should contain_manila_config('DEFAULT/syslog_log_facility').with_value('LOG_LOCAL0') }
+  end
+
+  describe 'with log_dir disabled' do
+    let(:params) { req_params.merge!({:log_dir => false}) }
+    it { should contain_manila_config('DEFAULT/log_dir').with_ensure('absent') }
+  end
+
+  describe 'with amqp_durable_queues disabled' do
+    let :params do
+      req_params
+    end
+
+    it { should contain_manila_config('DEFAULT/amqp_durable_queues').with_value(false) }
+  end
+
+  describe 'with amqp_durable_queues enabled' do
+    let :params do
+      req_params.merge({
+        :amqp_durable_queues => true,
+      })
+    end
+
+    it { should contain_manila_config('DEFAULT/amqp_durable_queues').with_value(true) }
+  end
+
+  describe 'with sqlite' do
+    let :params do
+      {
+        :sql_connection        => 'sqlite:////var/lib/manila/manila.sqlite',
+        :rabbit_password       => 'guest',
+      }
+    end
+
+    it { should contain_manila_config('DEFAULT/sql_connection').with(
+      :value  => 'sqlite:////var/lib/manila/manila.sqlite',
+      :secret => true
+    ) }
+    it { should_not contain_class('mysql::python') }
+    it { should_not contain_class('mysql::bindings') }
+    it { should_not contain_class('mysql::bindings::python') }
+  end
+
+  describe 'with SSL socket options set' do
+    let :params do
+      {
+        :use_ssl         => true,
+        :cert_file       => '/path/to/cert',
+        :ca_file         => '/path/to/ca',
+        :key_file        => '/path/to/key',
+        :rabbit_password => 'guest',
+      }
+    end
+
+    it { should contain_manila_config('DEFAULT/ssl_ca_file').with_value('/path/to/ca') }
+    it { should contain_manila_config('DEFAULT/ssl_cert_file').with_value('/path/to/cert') }
+    it { should contain_manila_config('DEFAULT/ssl_key_file').with_value('/path/to/key') }
+  end
+
+  describe 'with SSL socket options set to false' do
+    let :params do
+      {
+        :use_ssl         => false,
+        :cert_file       => false,
+        :ca_file         => false,
+        :key_file        => false,
+        :rabbit_password => 'guest',
+      }
+    end
+
+    it { should contain_manila_config('DEFAULT/ssl_ca_file').with_ensure('absent') }
+    it { should contain_manila_config('DEFAULT/ssl_cert_file').with_ensure('absent') }
+    it { should contain_manila_config('DEFAULT/ssl_key_file').with_ensure('absent') }
+  end
+
+  describe 'with SSL socket options set wrongly configured' do
+    let :params do
+      {
+        :use_ssl         => true,
+        :ca_file         => '/path/to/ca',
+        :key_file        => '/path/to/key',
+        :rabbit_password => 'guest',
+      }
+    end
+
+    it 'should raise an error' do
+      expect {
+        should compile
+      }.to raise_error Puppet::Error, /The cert_file parameter is required when use_ssl is set to true/
+    end
+  end
+
+end

--- a/manila/spec/defines/manila_backend_generic_spec.rb
+++ b/manila/spec/defines/manila_backend_generic_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'manila::backend::generic' do
+
+  let(:title) {'hippo'}
+
+  let :params do
+    {
+      :smb_template_config_path         => '$state_path/smb.conf',
+      :volume_name_template             => 'manila-share-%s',
+      :volume_snapshot_name_template    => 'manila-snapshot-%s',
+      :share_mount_path                 => '/shares',
+      :max_time_to_create_volume        => 180,
+      :max_time_to_attach               => 120,
+      :service_instance_smb_config_path => '$share_mount_path/smb.conf',
+      :share_helpers                    => ['CIFS=manila.share.drivers.generic.CIFSHelper',
+                                            'NFS=manila.share.drivers.generic.NFSHelper'],
+      :share_volume_fstype              => 'ext4',
+    }
+  end
+
+  describe 'generic share driver' do
+
+    it 'configures generic share driver' do
+      should contain_manila_config('hippo/share_backend_name').with(
+        :value => 'hippo')
+      should contain_manila_config('hippo/share_driver').with_value(
+        'manila.share.drivers.generic.GenericShareDriver')
+      params.each_pair do |config,value|
+        should contain_manila_config("hippo/#{config}").with_value( value )
+      end
+    end
+  end
+end

--- a/manila/spec/defines/manila_backend_glusterfs_spec.rb
+++ b/manila/spec/defines/manila_backend_glusterfs_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'manila::backend::glusterfs' do
+
+  shared_examples_for 'glusterfs share driver' do
+    let(:title) {'mygluster'}
+
+    let :params do
+      {
+        :glusterfs_volumes_config    => '/etc/manila/glusterfs_volumes',
+        :glusterfs_mount_point_base  => '$state_path/mnt',
+      }
+    end
+
+    it 'configures glusterfs share driver' do
+      should contain_manila_config('mygluster/share_backend_name').with_value(
+        'mygluster')
+      should contain_manila_config('mygluster/share_driver').with_value(
+        'manila.share.drivers.glusterfs.GlusterfsShareDriver')
+      should contain_manila_config('mygluster/glusterfs_volumes_config').with_value(
+        '/etc/manila/glusterfs_volumes')
+      should contain_manila_config('mygluster/glusterfs_mount_point_base').with_value(
+        '$state_path/mnt')
+    end
+  end
+
+  context 'on Debian platforms' do
+    let :facts do
+      { :osfamily => 'Debian' }
+    end
+
+    it_configures 'glusterfs share driver'
+  end
+
+  context 'on RedHat platforms' do
+    let :facts do
+      { :osfamily => 'RedHat' }
+    end
+
+    it_configures 'glusterfs share driver'
+  end
+
+end

--- a/manila/spec/defines/manila_backend_netapp_spec.rb
+++ b/manila/spec/defines/manila_backend_netapp_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'manila::backend::netapp' do
+
+  let(:title) {'mynetapp'}
+
+  let :params do
+    {
+      :netapp_nas_login             => 'netapp',
+      :netapp_nas_password          => 'password',
+      :netapp_nas_server_hostname   => '127.0.0.2',
+      :netapp_root_volume_aggregate => 'aggr1',
+    }
+  end
+
+  let :default_params do
+    {
+      :netapp_nas_transport_type            => 'http',
+      :netapp_nas_volume_name_template      => 'share_%(share_id)s',
+      :netapp_vserver_name_template         => 'os_%s',
+      :netapp_lif_name_template             => 'os_%(net_allocation_id)s',
+      :netapp_aggregate_name_search_pattern => '(.*)',
+      :netapp_root_volume_name              => 'root',
+    }
+  end
+
+  shared_examples_for 'netapp share driver' do
+    let :params_hash do
+      default_params.merge(params)
+    end
+
+    it 'configures netapp share driver' do
+      should contain_manila_config("mynetapp/share_driver").with_value(
+        'manila.share.drivers.netapp.cluster_mode.NetAppClusteredShareDriver')
+      params_hash.each_pair do |config,value|
+        should contain_manila_config("mynetapp/#{config}").with_value( value )
+      end
+    end
+
+    it 'marks netapp_password as secret' do
+      should contain_manila_config("mynetapp/netapp_nas_password").with_secret( true )
+    end
+  end
+
+
+  context 'with default parameters' do
+    before do
+      params = {}
+    end
+
+    it_configures 'netapp share driver'
+  end
+
+  context 'with provided parameters' do
+    it_configures 'netapp share driver'
+  end
+
+end

--- a/manila/spec/defines/manila_type_set_spec.rb
+++ b/manila/spec/defines/manila_type_set_spec.rb
@@ -1,0 +1,29 @@
+#Author: Andrew Woodward <awoodward@mirantis.com>
+
+require 'spec_helper'
+
+describe 'manila::type_set' do
+
+  let(:title) {'hippo'}
+
+  let :params do {
+    :type           => 'sith',
+    :key            => 'monchichi',
+    :os_password    => 'asdf',
+    :os_tenant_name => 'admin',
+    :os_username    => 'admin',
+    :os_auth_url    => 'http://127.127.127.1:5000/v2.0/',
+  }
+  end
+
+  it 'should have its execs' do
+    should contain_exec('manila type-key sith set monchichi=hippo').with(
+      :command => 'manila type-key sith set monchichi=hippo',
+      :environment => [
+        'OS_TENANT_NAME=admin',
+        'OS_USERNAME=admin',
+        'OS_PASSWORD=asdf',
+        'OS_AUTH_URL=http://127.127.127.1:5000/v2.0/'],
+      :require => 'Package[python-manilaclient]')
+  end
+end

--- a/manila/spec/defines/manila_type_spec.rb
+++ b/manila/spec/defines/manila_type_spec.rb
@@ -1,0 +1,32 @@
+#Author: Andrew Woodward <awoodward@mirantis.com>
+
+require 'spec_helper'
+
+describe 'manila::type' do
+
+  let(:title) {'hippo'}
+
+  let :params do {
+    :set_value      => ['name1','name2'],
+    :set_key        => 'volume_backend_name',
+    :os_password    => 'asdf',
+    :os_tenant_name => 'admin',
+    :os_username    => 'admin',
+    :os_auth_url    => 'http://127.127.127.1:5000/v2.0/',
+  }
+  end
+
+  it 'should have its execs' do
+    should contain_exec('manila type-create hippo').with(
+      :command => 'manila type-create hippo',
+      :environment => [
+        'OS_TENANT_NAME=admin',
+        'OS_USERNAME=admin',
+        'OS_PASSWORD=asdf',
+        'OS_AUTH_URL=http://127.127.127.1:5000/v2.0/'],
+      :unless  => 'manila type-list | grep hippo',
+      :require => 'Package[python-manilaclient]')
+    should contain_exec('manila type-key hippo set volume_backend_name=name1')
+    should contain_exec('manila type-key hippo set volume_backend_name=name2')
+  end
+end

--- a/manila/spec/shared_examples.rb
+++ b/manila/spec/shared_examples.rb
@@ -1,0 +1,5 @@
+shared_examples_for "a Puppet::Error" do |description|
+  it "with message matching #{description.inspect}" do
+    expect { should have_class_count(1) }.to raise_error(Puppet::Error, description)
+  end
+end

--- a/manila/spec/spec_helper.rb
+++ b/manila/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'shared_examples'
+
+RSpec.configure do |c|
+  c.alias_it_should_behave_like_to :it_configures, 'configures'
+  c.alias_it_should_behave_like_to :it_raises, 'raises'
+end


### PR DESCRIPTION
[This change to Packstack](https://review.openstack.org/#/c/127262) to enable the installation of Manila requires that puppet-manila be in these repositories.  Is there anything else that I need to do other than add the module to the Puppetfile?
