### PR TITLE
Fix travis changed module detection

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 set -ev
-MODS="$(git diff HEAD~1 Puppetfile | grep ^- -B2 | grep mod | cut -d"'" -f2)"
+MODS="$(git diff HEAD~1 Puppetfile | grep ^+ -B2 | grep mod | cut -d"'" -f2)"
 rake validate_puppetfile SPEC_OPTS='--format documentation --color --backtrace' || exit 1
-for module in ${MODS}; do
-  if [ -e ./${module}/Rakefile ]; then
-    rake test_modules[./${module}/Rakefile] SPEC_OPTS='--format documentation --color --backtrace' || exit 1
-  else
-    echo "Missing ./${module}/Rakefile, not running spec tests."
-  fi
-done
+if [ "${MODS}" != "" ]; then
+  for module in ${MODS}; do
+    if [ -e ./${module}/Rakefile ]; then
+      rake test_modules[./${module}/Rakefile] SPEC_OPTS='--format documentation --color --backtrace' || exit 1
+    else
+      echo "Missing ./${module}/Rakefile, not running spec tests. You have to manually check whether this is OK."
+      exit 1
+    fi
+  done
+else
+  echo "No changed module detected. You have to manually check whether this is OK."
+  git diff HEAD~1 Puppetfile
+  exit 1
+fi


### PR DESCRIPTION
If new module was added the dif contains only + and no - so from
now we chack on ^+ in Puppetfile diff.

(cherry picked from commit de49d50ff70d4320201ff59383a62ff508002c71)
