### PR TITLE
Automatic update (juno) :: advance puppet-redis to 1.0.2

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -131,7 +131,7 @@ mod 'rabbitmq',
   :git => 'https://github.com/puppetlabs/puppetlabs-rabbitmq.git'
 
 mod 'redis',
-  :commit => '31ecbcace3cacf26ad85d90abc2409da8973e788',
+  :commit => 'f4ffa1b907281472c8572c7dbcee8d2f454f3e27',
   :git => 'https://github.com/arioch/puppet-redis.git'
 
 mod 'rsync',

--- a/redis/README.md
+++ b/redis/README.md
@@ -41,6 +41,21 @@ On Ubuntu, "chris-lea/redis-server" ppa repo will be added. You can change it by
       manage_repo => true,
       ppa_repo    => 'ppa:rwky/redis',
     }
+### Redis Sentinel
+
+Optionally install and configuration a redis-sentinel server.
+
+With default settings:
+
+    class { 'redis::sentinel':}
+
+With adjustments:
+
+    class { 'redis::sentinel':
+      master_name => 'cow',
+      redis_host  => '192.168.1.5',
+      failover_timeout => 30000,
+    }
 
 ## Unit testing
 

--- a/redis/manifests/params.pp
+++ b/redis/manifests/params.pp
@@ -35,6 +35,18 @@ class redis::params {
   $port                        = 6379
   $rdbcompression              = true
   $requirepass                 = undef
+  $sentinel_config_file_mode   = '0644'
+  $sentinel_config_group       = 'root'
+  $sentinel_config_owner       = 'redis'
+  $sentinel_conf_template      = 'redis/redis-sentinel.conf.erb'
+  $sentinel_down_after         = 30000
+  $sentinel_failover_timeout   = 180000
+  $sentinel_master_name        = 'mymaster'
+  $sentinel_parallel_sync      = 1
+  $sentinel_port               = 26379
+  $sentinel_quorum             = 2
+  $sentinel_service_name       = 'redis-sentinel'
+  $sentinel_working_dir        = '/tmp'
   $set_max_intset_entries      = 512
   $slowlog_log_slower_than     = 10000
   $slowlog_max_len             = 1024
@@ -56,40 +68,44 @@ class redis::params {
 
   case $::osfamily {
     'Debian': {
-      $config_dir         = '/etc/redis'
-      $config_dir_mode    = '0755'
-      $config_file        = '/etc/redis/redis.conf'
-      $config_file_mode   = '0644'
-      $config_group       = 'root'
-      $config_owner       = 'root'
-      $package_ensure     = 'present'
-      $package_name       = 'redis-server'
-      $service_enable     = true
-      $service_ensure     = 'running'
-      $service_group      = 'redis'
-      $service_hasrestart = true
-      $service_hasstatus  = false
-      $service_name       = 'redis-server'
-      $service_user       = 'redis'
-      $ppa_repo           = 'ppa:chris-lea/redis-server'
+      $config_dir                = '/etc/redis'
+      $config_dir_mode           = '0755'
+      $config_file               = '/etc/redis/redis.conf'
+      $config_file_mode          = '0644'
+      $config_group              = 'root'
+      $config_owner              = 'root'
+      $package_ensure            = 'present'
+      $package_name              = 'redis-server'
+      $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
+      $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $service_enable            = true
+      $service_ensure            = 'running'
+      $service_group             = 'redis'
+      $service_hasrestart        = true
+      $service_hasstatus         = false
+      $service_name              = 'redis-server'
+      $service_user              = 'redis'
+      $ppa_repo                  = 'ppa:chris-lea/redis-server'
     }
 
     'RedHat': {
-      $config_dir         = '/etc/redis'
-      $config_dir_mode    = '0755'
-      $config_file        = '/etc/redis.conf'
-      $config_file_mode   = '0644'
-      $config_group       = 'root'
-      $config_owner       = 'root'
-      $package_ensure     = 'present'
-      $package_name       = 'redis'
-      $service_enable     = true
-      $service_ensure     = 'running'
-      $service_group      = 'redis'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_name       = 'redis'
-      $service_user       = 'redis'
+      $config_dir                = '/etc/redis'
+      $config_dir_mode           = '0755'
+      $config_file               = '/etc/redis.conf'
+      $config_file_mode          = '0644'
+      $config_group              = 'root'
+      $config_owner              = 'root'
+      $package_ensure            = 'present'
+      $package_name              = 'redis'
+      $sentinel_config_file      = '/etc/redis-sentinel.conf'
+      $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
+      $service_enable            = true
+      $service_ensure            = 'running'
+      $service_group             = 'redis'
+      $service_hasrestart        = true
+      $service_hasstatus         = true
+      $service_name              = 'redis'
+      $service_user              = 'redis'
     }
 
     default: {

--- a/redis/manifests/sentinel.pp
+++ b/redis/manifests/sentinel.pp
@@ -1,0 +1,162 @@
+# = Class: redis::sentinel
+#
+# This class install redis-sentinel
+#
+# == Parameters:
+#
+# [*config_file*]
+#   The location and name of the sentinel config file.
+#
+#   Default for deb: /etc/redis/redis-sentinel.conf
+#   Default for rpm: /etc/redis-sentinel.conf
+#
+# [*config_file_orig*]
+#   The location and name of a config file that provides the source
+#   of the sentinel config file. Two different files are needed
+#   because sentinel itself writes to its own config file and we do
+#   not want override that when puppet is run unless there are
+#   changes from the manifests.
+#
+#   Default for deb: /etc/redis/redis-sentinel.conf.puppet
+#   Default for rpm: /etc/redis-sentinel.conf.puppet
+#
+# [*config_file_mode*]
+#   Permissions of config file.
+#
+#   Default: 0644
+#
+# [*conf_template*]
+#   Define which template to use.
+#
+#   Default: redis/redis-sentinel.conf.erb
+#
+# [*down_after*]
+#   Number of milliseconds the master (or any attached slave or sentinel)
+#   should be unreachable (as in, not acceptable reply to PING, continuously,
+#   for the specified period) in order to consider it in S_DOWN state.
+#
+#   Default: 30000
+#
+# [*failover_timeout*]
+#   Specify the failover timeout in milliseconds.
+#
+#   Default: 180000
+#
+# [*log_file*]
+#   Specify where to write log entries.
+#
+#   Default: /var/log/redis/redis.log
+#
+# [*master_name*]
+#   Specify the name of the master redis server.
+#   The valid charset is A-z 0-9 and the three characters ".-_".
+#
+#   Default: mymaster
+#
+# [*redis_host*]
+#   Specify the bound host of the master redis server.
+#
+#   Default: 127.0.0.1
+#
+# [*redis_port*]
+#   Specify the port of the master redis server.
+#
+#   Default: 6379
+#
+# [*parallel_sync*]
+#   How many slaves can be reconfigured at the same time to use a
+#   new master after a failover.
+#
+#   Default: 1
+#
+# [*quorum*]
+#   Number of sentinels that must agree that a master is down to
+#   signal sdown state.
+#
+#   Default: 2
+#
+# [*sentinel_port*]
+#   The port of sentinel server.
+#
+#   Default: 26379
+#
+# [*service_group*]
+#   The group of the config file.
+#
+#   Default: redis
+#
+# [*service_name*]
+#   The name of the service (for puppet to manage).
+#
+#   Default: redis-sentinel
+#
+# [*service_owner*]
+#   The owner of the config file.
+#
+#   Default: redis
+#
+# [*working_dir*]
+#   The directory into which sentinel will change to avoid mount
+#   conflicts.
+#
+#   Default: /tmp
+#
+# == Actions:
+#   - Install and configure Redis Sentinel
+#
+# == Sample Usage:
+#
+#   class { 'redis::sentinel': }
+#
+#   class {'redis::sentinel':
+#     down_after => 80000,
+#     log_file => '/var/log/redis/sentinel.log',
+#   }
+#
+class redis::sentinel (
+  $config_file       = $::redis::params::sentinel_config_file,
+  $config_file_orig  = $::redis::params::sentinel_config_file_orig,
+  $config_file_mode  = $::redis::params::sentinel_config_file_mode,
+  $conf_template     = $::redis::params::sentinel_conf_template,
+  $down_after        = $::redis::params::sentinel_down_after,
+  $failover_timeout  = $::redis::params::sentinel_failover_timeout,
+  $log_file          = $::redis::params::log_file,
+  $master_name       = $::redis::params::sentinel_master_name,
+  $redis_host        = $::redis::params::bind,
+  $redis_port        = $::redis::params::port,
+  $parallel_sync     = $::redis::params::sentinel_parallel_sync,
+  $quorum            = $::redis::params::sentinel_quorum,
+  $sentinel_port     = $::redis::params::sentinel_port,
+  $service_group     = $::redis::params::service_group,
+  $service_name      = $::redis::params::sentinel_service_name,
+  $service_user      = $::redis::params::service_user,
+  $working_dir       = $::redis::params::sentinel_working_dir,
+) inherits redis::params {
+
+  file {
+    $config_file_orig:
+      ensure  => present,
+      content => template($conf_template);
+
+    $config_file:
+      owner => $service_user,
+      group => $service_group,
+      mode  => $config_file_mode;
+  }
+
+  exec {
+    "cp ${config_file_orig} ${config_file}":
+      path        => '/usr/bin:/bin',
+      subscribe   => File[$config_file_orig],
+      notify      => Service[$service_name],
+      refreshonly => true;
+  }
+
+  service { $service_name:
+    ensure     => $::redis::params::service_ensure,
+    enable     => $::redis::params::service_enable,
+    hasrestart => $::redis::params::service_hasrestart,
+    hasstatus  => $::redis::params::service_hasstatus,
+  }
+
+}

--- a/redis/metadata.json
+++ b/redis/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "arioch-redis",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Tom De Vylder",
   "summary": "Redis module",
   "license": "Apache License, Version 2.0",
@@ -9,10 +9,11 @@
   "issues_url": "https://github.com/arioch/puppet-redis/issues",
   "description": "Redis module with cluster support",
   "tags": [
-    "redis",
     "cluster",
     "failover",
-    "loadbalancing"
+    "loadbalancing",
+    "redis",
+    "sentinel"
   ],
   "operatingsystem_support": [
     {

--- a/redis/spec/classes/redis_sentinel_spec.rb
+++ b/redis/spec/classes/redis_sentinel_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+$expected_noparams_content = <<EOF
+port 26379
+dir /tmp
+
+sentinel monitor mymaster 127.0.0.1 6379 2
+sentinel down-after-milliseconds mymaster 30000
+sentinel parallel-syncs mymaster 1
+sentinel failover-timeout mymaster 180000
+
+logfile /var/log/redis/redis.log
+EOF
+
+$expected_params_content = <<EOF
+port 26379
+dir /tmp
+
+sentinel monitor cow 127.0.0.1 6379 2
+sentinel down-after-milliseconds cow 6000
+sentinel parallel-syncs cow 1
+sentinel failover-timeout cow 28000
+
+logfile /tmp/barn-sentinel.log
+EOF
+
+describe 'redis::sentinel', :type => :class do
+  let (:facts) { debian_facts }
+
+  describe 'without parameters' do
+
+    it { should create_class('redis::sentinel') }
+
+    it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
+        'ensure'  => 'present',
+        'content' => $expected_noparams_content
+      )
+    }
+
+    it { should contain_file('/etc/redis/redis-sentinel.conf').with(
+        'mode' => '0644'
+      )
+    }
+
+    it { should contain_service('redis-sentinel').with(
+        'ensure'     => 'running',
+        'enable'     => 'true',
+        'hasrestart' => 'true',
+        'hasstatus'  => 'false'
+      )
+    }
+
+  end
+
+  describe 'with custom parameters' do
+    let (:params) {
+      {
+        :master_name      => 'cow',
+        :down_after       => 6000,
+        :log_file         => '/tmp/barn-sentinel.log',
+        :failover_timeout => 28000
+      }
+    }
+
+    it { should create_class('redis::sentinel') }
+
+    it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
+        'content' => $expected_params_content
+      )
+    }
+  end
+
+end

--- a/redis/templates/redis-sentinel.conf.erb
+++ b/redis/templates/redis-sentinel.conf.erb
@@ -1,0 +1,9 @@
+port <%= @sentinel_port %>
+dir <%= @working_dir %>
+
+sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
+sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>
+sentinel parallel-syncs <%= @master_name %> <%= @parallel_sync %>
+sentinel failover-timeout <%= @master_name %> <%= @failover_timeout %>
+
+logfile <%= @log_file %>


### PR DESCRIPTION
This module update commit was generated by Bade.
For more info please check https://github.com/paramite/bade

This commit is setting modules to following state:
redis
- old commit: 31ecbcace3cacf26ad85d90abc2409da8973e788
- new commit: f4ffa1b907281472c8572c7dbcee8d2f454f3e27
