### PR TITLE
Add Ironic support into nova puppet modules

### DIFF
--- a/nova/manifests/compute.pp
+++ b/nova/manifests/compute.pp
@@ -73,6 +73,16 @@
 #   (optional) Force backing images to raw format.
 #   Defaults to true
 #
+#  [*reserved_host_memory*]
+#   Reserved host memory
+#   The amount of memory in MB reserved for the host.
+#   Defaults to '512'
+#
+#  [*compute_manager*]
+#   Compute manager
+#   The driver that will manage the running instances.
+#   Defaults to nova.compute.manager.ComputeManager
+#
 class nova::compute (
   $enabled                       = false,
   $manage_service                = true,
@@ -91,9 +101,16 @@ class nova::compute (
   $instance_usage_audit          = false,
   $instance_usage_audit_period   = 'month',
   $force_raw_images              = true,
+  $reserved_host_memory          = '512',
+  $compute_manager               = 'nova.compute.manager.ComputeManager',
 ) {
 
   include nova::params
+
+  nova_config {
+    'DEFAULT/reserved_host_memory_mb':  value => $reserved_host_memory;
+    'DEFAULT/compute_manager':          value => $compute_manager;
+  }
 
   if ($vnc_enabled) {
     if ($vncproxy_host) {

--- a/nova/manifests/compute/ironic.pp
+++ b/nova/manifests/compute/ironic.pp
@@ -1,0 +1,49 @@
+# == Class: nova::compute::ironic
+#
+# Configures Nova compute service to use Ironic.
+#
+# === Parameters:
+#
+# [*admin_user*]
+#   Admin username
+#   The admin username for Ironic to connect to Nova.
+#   Defaults to 'admin'
+#
+# [*admin_passwd*]
+#   Admin password
+#   The admin password for Ironic to connect to Nova.
+#   Defaults to 'ironic'
+#
+# [*admin_url*]
+#   Admin url
+#   The address of the Keystone api endpoint.
+#   Defaults to 'http://127.0.0.1:35357/v2.0'
+#
+# [*admin_tenant_name*]
+#   Admin tenant name
+#   The Ironic Keystone tenant name.
+#   Defaults to 'services'
+#
+# [*api_endpoint*]
+#   Api endpoint
+#   The url for Ironic api endpoint.
+#   Defaults to 'http://127.0.0.1:6385/v1'
+#
+
+class nova::compute::ironic (
+  $admin_user           = 'admin',
+  $admin_passwd         = 'ironic',
+  $admin_url            = 'http://127.0.0.1:35357/v2.0',
+  $admin_tenant_name    = 'services',
+  $api_endpoint         = 'http://127.0.0.1:6385/v1',
+) {
+
+  nova_config {
+    'ironic/admin_username':            value => $admin_user;
+    'ironic/admin_password':            value => $admin_passwd;
+    'ironic/admin_url':                 value => $admin_url;
+    'ironic/admin_tenant_name':         value => $admin_tenant_name;
+    'ironic/api_endpoint':              value => $api_endpoint;
+    'DEFAULT/compute_driver':           value => 'nova.virt.ironic.IronicDriver';
+  }
+}

--- a/nova/spec/classes/nova_compute_spec.rb
+++ b/nova/spec/classes/nova_compute_spec.rb
@@ -40,11 +40,13 @@ describe 'nova::compute' do
 
     context 'with overridden parameters' do
       let :params do
-        { :enabled            => true,
-          :ensure_package     => '2012.1-2',
-          :vncproxy_host      => '127.0.0.1',
-          :network_device_mtu => 9999,
-          :force_raw_images   => false }
+        { :enabled              => true,
+          :ensure_package       => '2012.1-2',
+          :vncproxy_host        => '127.0.0.1',
+          :network_device_mtu   => 9999,
+          :force_raw_images     => false,
+          :reserved_host_memory => '0',
+          :compute_manager      => 'ironic.nova.compute.manager.ClusteredComputeManager'}
       end
 
       it 'installs nova-compute package and service' do
@@ -59,6 +61,11 @@ describe 'nova::compute' do
           :ensure => '2012.1-2',
           :tag    => ['openstack', 'nova']
         })
+      end
+
+      it 'configures ironic in nova.conf' do
+        should contain_nova_config('DEFAULT/reserved_host_memory_mb').with_value('0')
+        should contain_nova_config('DEFAULT/compute_manager').with_value('ironic.nova.compute.manager.ClusteredComputeManager')
       end
 
       it 'configures network_device_mtu' do


### PR DESCRIPTION
Ironic needs to make some additions to the nova config
file in order to run.  The remaining configuraitons will
be added to the nova plugin in packstack.
