### PR TITLE
Automatic update :: advancing puppet-redis to latest master upstream

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -139,7 +139,7 @@ mod 'rabbitmq',
   :git => 'https://github.com/puppetlabs/puppetlabs-rabbitmq.git'
 
 mod 'redis',
-  :commit => 'f4ffa1b907281472c8572c7dbcee8d2f454f3e27',
+  :commit => 'd72af9ab3c2911b6dc18c5cc12e700630ebdcfb2',
   :git => 'https://github.com/arioch/puppet-redis.git'
 
 mod 'rsync',

--- a/redis/manifests/sentinel.pp
+++ b/redis/manifests/sentinel.pp
@@ -133,19 +133,23 @@ class redis::sentinel (
   $working_dir       = $::redis::params::sentinel_working_dir,
 ) inherits redis::params {
 
+
+  package { $::redis::params::package_name:
+    ensure => $::redis::params::package_ensure,
+  }
+
   file {
     $config_file_orig:
       ensure  => present,
-      content => template($conf_template);
-
-    $config_file:
-      owner => $service_user,
-      group => $service_group,
-      mode  => $config_file_mode;
+      owner   => $service_user,
+      group   => $service_group,
+      mode    => $config_file_mode,
+      content => template($conf_template),
+      require => Package[$::redis::params::package_name];
   }
 
   exec {
-    "cp ${config_file_orig} ${config_file}":
+    "cp -p ${config_file_orig} ${config_file}":
       path        => '/usr/bin:/bin',
       subscribe   => File[$config_file_orig],
       notify      => Service[$service_name],

--- a/redis/metadata.json
+++ b/redis/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "arioch-redis",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Tom De Vylder",
   "summary": "Redis module",
   "license": "Apache License, Version 2.0",
@@ -38,6 +38,13 @@
       ]
     },
     {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "14.10"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6.0",
@@ -61,6 +68,8 @@
     }
   ],
   "dependencies": [
-  
+    {
+      "name": "puppetlabs/apt"
+    }
   ]
 }

--- a/redis/spec/classes/redis_sentinel_spec.rb
+++ b/redis/spec/classes/redis_sentinel_spec.rb
@@ -33,12 +33,9 @@ describe 'redis::sentinel', :type => :class do
 
     it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
         'ensure'  => 'present',
+        'mode'    => '0644',
+        'owner'   => 'redis',
         'content' => $expected_noparams_content
-      )
-    }
-
-    it { should contain_file('/etc/redis/redis-sentinel.conf').with(
-        'mode' => '0644'
       )
     }
 


### PR DESCRIPTION
This module update commit was generated by Bade.
For more info please check https://github.com/paramite/bade

This commit is setting modules to following state:
redis
 - old commit: f4ffa1b907281472c8572c7dbcee8d2f454f3e27
 - new commit: b820d82dcf1b4631f6acb63d65be617a2fb64b8a