### PR TITLE
Python-pbr needs to be removed as a dependancy

### DIFF
--- a/ironic/manifests/init.pp
+++ b/ironic/manifests/init.pp
@@ -173,15 +173,9 @@ class ironic (
     mode    => '0640',
   }
 
-  package { 'python-pbr':
-    ensure => $package_ensure,
-    name   => $::ironic::params::pbr_package,
-  }
-
   package { 'ironic-common':
     ensure  => $package_ensure,
     name    => $::ironic::params::common_package_name,
-    require => Package['python-pbr'],
   }
 
   validate_re($database_connection, '(sqlite|mysql|postgresql):\/\/(\S+:\S+@\S+\/\S+)?')

--- a/ironic/manifests/params.pp
+++ b/ironic/manifests/params.pp
@@ -31,7 +31,6 @@ class ironic::params {
       $conductor_package   = 'openstack-ironic-conductor'
       $conductor_service   = 'openstack-ironic-conductor'
       $client_package      = 'python-ironicclient'
-      $pbr_package         = 'python-pbr'
     }
     'Debian': {
       $common_package_name = 'ironic-common'
@@ -40,7 +39,6 @@ class ironic::params {
       $conductor_service   = 'ironic-conductor'
       $conductor_package   = 'ironic-conductor'
       $client_package      = 'python-ironicclient'
-      $pbr_package         = 'python-pbr'
     }
     default: {
       fail("Unsupported osfamily ${::osfamily}")


### PR DESCRIPTION
Red Hat no longer ships python-pbr so requiring this package
will cause Ironic installations to fail.