### PR TITLE
puppetfile: update to mongodb/master

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -139,7 +139,7 @@ mod 'memcached',
   :ref => 'd009260de3c7623003318555ec5ca61217ea3ca1'
 mod 'mongodb',
   :git => 'git://github.com/enovance/puppetlabs-mongodb.git',
-  :ref => '7aea8c07eb70847ebe4b37dc0f86372e863c7b3f'
+  :ref => '8e9ceced8e53f42152e1be8e3b18ba2c2e1e20c1'
 mod 'mysql',
   :git => 'git://github.com/enovance/puppetlabs-mysql.git',
   :ref => '8b814d4d2cb5786a15e8e37fb3b7444d5d5f0d3f'


### PR DESCRIPTION
Using this commit (last in master), we have MongoDB working on RHEL7 with OSP6 packaging.