### PR TITLE
Update puppet-heat to dc4861e396c6c992e1bfc26cd3dc5cf47b3021ce

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -47,7 +47,7 @@ mod 'haproxy',
   :git => 'https://github.com/puppetlabs/puppetlabs-haproxy.git'
 
 mod 'heat',
-  :commit => 'b1e9e9bd48c3da15be69c0797fb05e7ce0f6698f',
+  :commit => 'dc4861e396c6c992e1bfc26cd3dc5cf47b3021ce',
   :git => 'https://github.com/stackforge/puppet-heat.git'
 
 mod 'horizon',

--- a/heat/.fixtures.yml
+++ b/heat/.fixtures.yml
@@ -1,12 +1,14 @@
 fixtures:
   repositories:
     "inifile": "git://github.com/puppetlabs/puppetlabs-inifile"
+    'concat': 'git://github.com/puppetlabs/puppetlabs-concat.git'
     "keystone": "git://github.com/stackforge/puppet-keystone.git"
     "mysql":
       repo: 'git://github.com/puppetlabs/puppetlabs-mysql.git'
       ref: 'origin/2.2.x'
     "nova": "git://github.com/stackforge/puppet-nova.git"
     'openstacklib': 'git://github.com/stackforge/puppet-openstacklib.git'
+    'postgresql': 'git://github.com/puppetlabs/puppet-postgresql.git'
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     "heat": "#{source_dir}"

--- a/heat/Gemfile
+++ b/heat/Gemfile
@@ -5,6 +5,9 @@ group :development, :test do
   gem 'puppet-lint', '~> 1.1'
   gem 'puppet-lint-param-docs', '1.1.0'
   gem 'rake', '10.1.1'
+  gem 'rspec', '< 2.99'
+  gem 'json'
+  gem 'webmock'
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']

--- a/heat/lib/puppet/provider/heat_domain_id_setter/ruby.rb
+++ b/heat/lib/puppet/provider/heat_domain_id_setter/ruby.rb
@@ -1,0 +1,183 @@
+## NB: This must work with Ruby 1.8!
+
+# This provider permits the stack_user_domain parameter in heat.conf
+# to be set by providing a domain_name to the Puppet module and
+# using the Keystone REST API to translate the name into the corresponding
+# UUID.
+#
+# This requires that tenant names be unique.  If there are multiple matches
+# for a given tenant name, this provider will raise an exception.
+
+require 'rubygems'
+require 'net/http'
+require 'json'
+
+class KeystoneError < Puppet::Error
+end
+
+class KeystoneConnectionError < KeystoneError
+end
+
+class KeystoneAPIError < KeystoneError
+end
+
+# Provides common request handling semantics to the other methods in
+# this module.
+#
+# +req+::
+#   An HTTPRequest object
+# +url+::
+#   A parsed URL (returned from URI.parse)
+def handle_request(req, url)
+    begin
+        res = Net::HTTP.start(url.host, url.port) {|http|
+            http.request(req)
+        }
+
+        if res.code != '200'
+            raise KeystoneAPIError, "Received error response from Keystone server at #{url}: #{res.message}"
+        end
+    rescue Errno::ECONNREFUSED => detail
+        raise KeystoneConnectionError, "Failed to connect to Keystone server at #{url}: #{detail}"
+    rescue SocketError => detail
+        raise KeystoneConnectionError, "Failed to connect to Keystone server at #{url}: #{detail}"
+    end
+
+    res
+end
+
+# Authenticates to a Keystone server and obtains an authentication token.
+# It returns a 2-element +[token, authinfo]+, where +token+ is a token
+# suitable for passing to openstack apis in the +X-Auth-Token+ header, and
+# +authinfo+ is the complete response from Keystone, including the service
+# catalog (if available).
+#
+# +auth_url+::
+#   Keystone endpoint URL.  This function assumes API version
+#   2.0 and an administrative endpoint, so this will typically look like
+#   +http://somehost:35357/v2.0+.
+#
+# +username+::
+#   Username for authentication.
+#
+# +password+::
+#   Password for authentication
+#
+# +tenantID+::
+#   Tenant UUID
+#
+# +tenantName+::
+#   Tenant name
+#
+def keystone_v2_authenticate(auth_url,
+                             username,
+                             password,
+                             tenantId=nil,
+                             tenantName=nil)
+
+    post_args = {
+        'auth' => {
+            'passwordCredentials' => {
+                'username' => username,
+                'password' => password
+            },
+        }}
+
+    if tenantId
+        post_args['auth']['tenantId'] = tenantId
+    end
+
+    if tenantName
+        post_args['auth']['tenantName'] = tenantName
+    end
+
+    url = URI.parse("#{auth_url}/tokens")
+    req = Net::HTTP::Post.new url.path
+    req['content-type'] = 'application/json'
+    req.body = post_args.to_json
+
+    res = handle_request(req, url)
+    data = JSON.parse res.body
+    return data['access']['token']['id'], data
+end
+
+# Queries a Keystone server to a list of all tenants.
+#
+# +auth_url+::
+#   Keystone endpoint.  See the notes for +auth_url+ in
+#   +keystone_v2_authenticate+.
+#
+# +token+::
+#   A Keystone token that will be passed in requests as the value of the
+#   +X-Auth-Token+ header.
+#
+def keystone_v3_domains(auth_url,
+                        token)
+
+    auth_url.sub!('v2.0', 'v3')
+    url = URI.parse("#{auth_url}/domains")
+    req = Net::HTTP::Get.new url.path
+    req['content-type'] = 'application/json'
+    req['x-auth-token'] = token
+
+    res = handle_request(req, url)
+    data = JSON.parse res.body
+    data['domains']
+end
+
+Puppet::Type.type(:heat_domain_id_setter).provide(:ruby) do
+    def authenticate
+        token, authinfo = keystone_v2_authenticate(
+            @resource[:auth_url],
+            @resource[:auth_username],
+            @resource[:auth_password],
+            nil,
+            @resource[:auth_tenant_name])
+
+        return token
+    end
+
+    def find_domain_by_name(token)
+        domains = keystone_v3_domains(
+            @resource[:auth_url],
+            token)
+        domains.select{|domain| domain['name'] == @resource[:domain_name]}
+    end
+
+    def exists?
+        false
+    end
+
+    def create
+        config
+    end
+
+    # This looks for the domain specified by the 'domain_name' parameter to
+    # the resource and returns the corresponding UUID if there is a single
+    # match.
+    #
+    # Raises a KeystoneAPIError if:
+    #
+    # - There are multiple matches, or
+    # - There are zero matches
+    def get_domain_id
+        token = authenticate
+        domains = find_domain_by_name(token)
+
+        if domains.length == 1
+            return domains[0]['id']
+        elsif domains.length > 1
+            name = domains[0]['name']
+            raise KeystoneAPIError, 'Found multiple matches for domain name "#{name}"'
+        else
+            raise KeystoneAPIError, 'Unable to find matching domain'
+        end
+    end
+
+    def config
+        Puppet::Type.type(:heat_config).new(
+            {:name => 'DEFAULT/stack_user_domain', :value => "#{get_domain_id}"}
+        ).create
+    end
+
+end

--- a/heat/lib/puppet/type/heat_config.rb
+++ b/heat/lib/puppet/type/heat_config.rb
@@ -40,4 +40,8 @@ Puppet::Type.newtype(:heat_config) do
     defaultto false
   end
 
+  def create
+    provider.create
+  end
+
 end

--- a/heat/lib/puppet/type/heat_domain_id_setter.rb
+++ b/heat/lib/puppet/type/heat_domain_id_setter.rb
@@ -1,0 +1,31 @@
+Puppet::Type.newtype(:heat_domain_id_setter) do
+
+    ensurable
+
+    newparam(:name, :namevar => true) do
+        desc 'The name of the setting to update'
+    end
+
+    newparam(:domain_name) do
+        desc 'The heat domain name'
+    end
+
+    newparam(:auth_url) do
+        desc 'The Keystone endpoint URL'
+        defaultto 'http://localhost:35357/v2.0'
+    end
+
+    newparam(:auth_username) do
+        desc 'Username with which to authenticate'
+        defaultto 'admin'
+    end
+
+    newparam(:auth_password) do
+        desc 'Password with which to authenticate'
+    end
+
+    newparam(:auth_tenant_name) do
+        desc 'Tenant name with which to authenticate'
+        defaultto 'admin'
+    end
+end

--- a/heat/manifests/db/postgresql.pp
+++ b/heat/manifests/db/postgresql.pp
@@ -1,0 +1,45 @@
+# == Class: heat::db::postgresql
+#
+# Class that configures postgresql for heat
+# Requires the Puppetlabs postgresql module.
+#
+# === Parameters
+#
+# [*password*]
+#   (Required) Password to connect to the database.
+#
+# [*dbname*]
+#   (Optional) Name of the database.
+#   Defaults to 'heat'.
+#
+# [*user*]
+#   (Optional) User to connect to the database.
+#   Defaults to 'heat'.
+#
+#  [*encoding*]
+#    (Optional) The charset to use for the database.
+#    Default to undef.
+#
+#  [*privileges*]
+#    (Optional) Privileges given to the database user.
+#    Default to 'ALL'
+#
+class heat::db::postgresql(
+  $password,
+  $dbname     = 'heat',
+  $user       = 'heat',
+  $encoding   = undef,
+  $privileges = 'ALL',
+) {
+
+  ::openstacklib::db::postgresql { 'heat':
+    password_hash => postgresql_password($user, $password),
+    dbname        => $dbname,
+    user          => $user,
+    encoding      => $encoding,
+    privileges    => $privileges,
+  }
+
+  ::Openstacklib::Db::Postgresql['heat'] ~> Exec<| title == 'heat-dbsync' |>
+
+}

--- a/heat/manifests/engine.pp
+++ b/heat/manifests/engine.pp
@@ -35,18 +35,22 @@
 #   used for stack locking
 #   Defaults to '2'
 #
-# [*trusts_delegated_roles*]
-#   (optional) Array of trustor roles to be delegated to heat.
-#   Defaults to ['heat_stack_owner']
-#
 # [*deferred_auth_method*]
 #   (optional) Select deferred auth method.
 #   Can be "password" or "trusts".
 #   Defaults to 'trusts'
 #
+# === Deprecated Parameters
+#
+# [*trusts_delegated_roles*]
+#   (optional) Array of trustor roles to be delegated to heat.
+#   Defaults to ['heat_stack_owner']
+#   Deprecated: Moved to heat::keystone::auth, will be removed in a future release.
+#
 # [*configure_delegated_roles*]
 #   (optional) Whether to configure the delegated roles.
 #   Defaults to true
+#   Deprecated: Moved to heat::keystone::auth, will be removed in a future release.
 #
 class heat::engine (
   $auth_encryption_key,
@@ -57,9 +61,9 @@ class heat::engine (
   $heat_waitcondition_server_url = 'http://127.0.0.1:8000/v1/waitcondition',
   $heat_watch_server_url         = 'http://127.0.0.1:8003',
   $engine_life_check_timeout     = '2',
-  $trusts_delegated_roles        = ['heat_stack_owner'],
   $deferred_auth_method          = 'trusts',
-  $configure_delegated_roles     = true,
+  $trusts_delegated_roles        = ['heat_stack_owner'],  #DEPRECATED
+  $configure_delegated_roles     = true,                  #DEPRECATED
 ) {
 
   include heat::params
@@ -82,6 +86,7 @@ class heat::engine (
   }
 
   if $configure_delegated_roles {
+    warning('configure_delegated_roles and trusts_delegated_roles are deprecated in this class')
     keystone_role { $trusts_delegated_roles:
       ensure => present,
     }

--- a/heat/manifests/init.pp
+++ b/heat/manifests/init.pp
@@ -70,7 +70,7 @@
 #   (Optional) SSL version to use (valid only if SSL enabled).
 #   Valid values are TLSv1, SSLv23 and SSLv3. SSLv2 may be
 #   available on some distributions.
-#   Defaults to 'SSLv3'
+#   Defaults to 'TLSv1'
 #
 # [*amqp_durable_queues*]
 #   (Optional) Use durable queues in amqp.
@@ -174,7 +174,7 @@ class heat(
   $kombu_ssl_ca_certs          = undef,
   $kombu_ssl_certfile          = undef,
   $kombu_ssl_keyfile           = undef,
-  $kombu_ssl_version           = 'SSLv3',
+  $kombu_ssl_version           = 'TLSv1',
   $amqp_durable_queues         = false,
   $qpid_hostname               = 'localhost',
   $qpid_port                   = 5672,

--- a/heat/manifests/keystone/auth.pp
+++ b/heat/manifests/keystone/auth.pp
@@ -78,6 +78,15 @@
 #   (Optional) Protocol for internal endpoint
 #   Defaults to 'http'
 #
+# [*trusts_delegated_roles*]
+#    (optional) Array of trustor roles to be delegated to heat.
+#    Defaults to ['heat_stack_owner']
+#
+# [*configure_delegated_roles*]
+#    (optional) Whether to configure the delegated roles.
+#    Defaults to false until the deprecated parameters in heat::engine
+#    are removed after Kilo.
+#
 class heat::keystone::auth (
   $password             = false,
   $email                = 'heat@localhost',
@@ -97,6 +106,8 @@ class heat::keystone::auth (
   $configure_endpoint   = true,
   $configure_user       = true,
   $configure_user_role  = true,
+  $trusts_delegated_roles    = ['heat_stack_owner'],
+  $configure_delegated_roles = false,
 ) {
 
   validate_string($password)
@@ -130,17 +141,17 @@ class heat::keystone::auth (
         ensure => present,
   }
 
-  keystone_service { $real_service_name:
-    ensure      => present,
-    type        => $service_type,
-    description => 'Openstack Orchestration Service',
-  }
-  if $configure_endpoint {
-    keystone_endpoint { "${region}/${real_service_name}":
-      ensure       => present,
-      public_url   => "${public_protocol}://${public_address}:${port}/${version}/%(tenant_id)s",
-      admin_url    => "${admin_protocol}://${admin_address}:${port}/${version}/%(tenant_id)s",
-      internal_url => "${internal_protocol}://${internal_address}:${port}/${version}/%(tenant_id)s",
+  if $configure_delegated_roles {
+    # Sanity warning - remove after we remove the deprecated items
+    if $heat::engine::configure_delegated_roles {
+      warning('both heat::engine and heat::keystone::auth are trying to configure delegated roles')
     }
+    keystone_role { $trusts_delegated_roles:
+      ensure => present,
+    }
+  }
+
+  heat_config {
+    'DEFAULT/trusts_delegated_roles': value => $trusts_delegated_roles;
   }
 }

--- a/heat/manifests/keystone/domain.pp
+++ b/heat/manifests/keystone/domain.pp
@@ -1,0 +1,73 @@
+# == Class: heat::keystone::domain
+#
+# Configures heat domain in Keystone.
+#
+# Note: Implementation is done by heat-keystone-setup-domain script temporarily
+#       because currently puppet-keystone does not support v3 API
+#
+# === Parameters
+#
+# [*auth_url*]
+#   Keystone auth url
+#
+# [*keystone_admin*]
+#   Keystone admin user
+#
+# [*keystone_password*]
+#   Keystone admin password
+#
+# [*keystone_tenant*]
+#   Keystone admin tenant name
+#
+# [*domain_name*]
+#   Heat domain name. Defaults to 'heat'.
+#
+# [*domain_admin*]
+#   Keystone domain admin user which will be created. Defaults to 'heat_admin'.
+#
+# [*domain_password*]
+#   Keystone domain admin user password. Defaults to 'changeme'.
+#
+class heat::keystone::domain (
+  $auth_url          = undef,
+  $keystone_admin    = undef,
+  $keystone_password = undef,
+  $keystone_tenant   = undef,
+  $domain_name       = 'heat',
+  $domain_admin      = 'heat_admin',
+  $domain_password   = 'changeme',
+) {
+
+  include heat::params
+
+  $cmd_evn = [
+    "OS_USERNAME=${keystone_admin}",
+    "OS_PASSWORD=${keystone_password}",
+    "OS_AUTH_URL=${auth_url}",
+    "HEAT_DOMAIN=${domain_name}",
+    "HEAT_DOMAIN_ADMIN=${domain_admin}",
+    "HEAT_DOMAIN_PASSWORD=${domain_password}"
+  ]
+  exec { 'heat_domain_create':
+    path        => '/usr/bin',
+    command     => 'heat-keystone-setup-domain &>/dev/null',
+    environment => $cmd_evn,
+    require     => Package['heat-common'],
+  }
+
+  heat_domain_id_setter { 'heat_domain_id':
+    ensure           => present,
+    domain_name      => $domain_name,
+    auth_url         => $auth_url,
+    auth_username    => $keystone_admin,
+    auth_password    => $keystone_password,
+    auth_tenant_name => $keystone_tenant,
+    require          => Exec['heat_domain_create'],
+  }
+
+  heat_config {
+    'DEFAULT/stack_domain_admin': value => $domain_admin;
+    'DEFAULT/stack_domain_admin_password': value => $domain_password;
+  }
+
+}

--- a/heat/spec/classes/heat_db_postgresql_spec.rb
+++ b/heat/spec/classes/heat_db_postgresql_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'heat::db::postgresql' do
+
+  let :req_params do
+    { :password => 'pw' }
+  end
+
+  let :pre_condition do
+    'include postgresql::server'
+  end
+
+  context 'on a RedHat osfamily' do
+    let :facts do
+      {
+        :osfamily                 => 'RedHat',
+        :operatingsystemrelease   => '7.0',
+        :concat_basedir => '/var/lib/puppet/concat'
+      }
+    end
+
+    context 'with only required parameters' do
+      let :params do
+        req_params
+      end
+
+      it { should contain_postgresql__server__db('heat').with(
+        :user     => 'heat',
+        :password => 'md5fd5c4fca491370aab732f903e2fb7c99'
+      )}
+    end
+
+  end
+
+  context 'on a Debian osfamily' do
+    let :facts do
+      {
+        :operatingsystemrelease => '7.8',
+        :operatingsystem        => 'Debian',
+        :osfamily               => 'Debian',
+        :concat_basedir => '/var/lib/puppet/concat'
+      }
+    end
+
+    context 'with only required parameters' do
+      let :params do
+        req_params
+      end
+
+      it { should contain_postgresql__server__db('heat').with(
+        :user     => 'heat',
+        :password => 'md5fd5c4fca491370aab732f903e2fb7c99'
+      )}
+    end
+
+  end
+
+end

--- a/heat/spec/classes/heat_engine_spec.rb
+++ b/heat/spec/classes/heat_engine_spec.rb
@@ -12,6 +12,7 @@ describe 'heat::engine' do
       :engine_life_check_timeout     => '2',
       :trusts_delegated_roles        => ['heat_stack_owner'],
       :deferred_auth_method          => 'trusts',
+      :configure_delegated_roles     => true,
     }
   end
 

--- a/heat/spec/classes/heat_init_spec.rb
+++ b/heat/spec/classes/heat_init_spec.rb
@@ -254,7 +254,7 @@ describe 'heat' do
         :kombu_ssl_ca_certs => '/path/to/ssl/ca/certs',
         :kombu_ssl_certfile => '/path/to/ssl/cert/file',
         :kombu_ssl_keyfile  => '/path/to/ssl/keyfile',
-        :kombu_ssl_version  => 'SSLv3'
+        :kombu_ssl_version  => 'TLSv1'
       )
     end
 
@@ -263,7 +263,7 @@ describe 'heat' do
       should contain_heat_config('DEFAULT/kombu_ssl_ca_certs').with_value('/path/to/ssl/ca/certs')
       should contain_heat_config('DEFAULT/kombu_ssl_certfile').with_value('/path/to/ssl/cert/file')
       should contain_heat_config('DEFAULT/kombu_ssl_keyfile').with_value('/path/to/ssl/keyfile')
-      should contain_heat_config('DEFAULT/kombu_ssl_version').with_value('SSLv3')
+      should contain_heat_config('DEFAULT/kombu_ssl_version').with_value('TLSv1')
     end
   end
 
@@ -279,7 +279,7 @@ describe 'heat' do
       should contain_heat_config('DEFAULT/kombu_ssl_ca_certs').with_ensure('absent')
       should contain_heat_config('DEFAULT/kombu_ssl_certfile').with_ensure('absent')
       should contain_heat_config('DEFAULT/kombu_ssl_keyfile').with_ensure('absent')
-      should contain_heat_config('DEFAULT/kombu_ssl_version').with_value('SSLv3')
+      should contain_heat_config('DEFAULT/kombu_ssl_version').with_value('TLSv1')
     end
   end
 
@@ -287,7 +287,7 @@ describe 'heat' do
     before do
       params.merge!(
         :rabbit_use_ssl     => false,
-        :kombu_ssl_version  => 'SSLv3'
+        :kombu_ssl_version  => 'TLSv1'
       )
     end
 

--- a/heat/spec/classes/heat_keystone_auth_spec.rb
+++ b/heat/spec/classes/heat_keystone_auth_spec.rb
@@ -4,21 +4,23 @@ describe 'heat::keystone::auth' do
 
   let :params do
     {
-      :password           => 'heat-passw0rd',
-      :email              => 'heat@localhost',
-      :auth_name          => 'heat',
-      :configure_endpoint => true,
-      :service_type       => 'orchestration',
-      :public_address     => '127.0.0.1',
-      :admin_address      => '127.0.0.1',
-      :internal_address   => '127.0.0.1',
-      :port               => '8004',
-      :version            => 'v1',
-      :region             => 'RegionOne',
-      :tenant             => 'services',
-      :public_protocol    => 'http',
-      :admin_protocol     => 'http',
-      :internal_protocol  => 'http',
+      :password                  => 'heat-passw0rd',
+      :email                     => 'heat@localhost',
+      :auth_name                 => 'heat',
+      :configure_endpoint        => true,
+      :service_type              => 'orchestration',
+      :public_address            => '127.0.0.1',
+      :admin_address             => '127.0.0.1',
+      :internal_address          => '127.0.0.1',
+      :port                      => '8004',
+      :version                   => 'v1',
+      :region                    => 'RegionOne',
+      :tenant                    => 'services',
+      :public_protocol           => 'http',
+      :admin_protocol            => 'http',
+      :internal_protocol         => 'http',
+      :trusts_delegated_roles    => ['heat_stack_owner'],
+      :configure_delegated_roles => false,
     }
   end
 
@@ -138,6 +140,23 @@ describe 'heat::keystone::auth' do
       :type         => 'orchestration',
       :description  => 'Openstack Orchestration Service'
     )}
+  end
+
+  context 'when configuring delegated roles' do
+    before do
+      params.merge!({
+        :configure_delegated_roles => true,
+        :trusts_delegated_roles    => ['role1','role2']
+      })
+    end
+    it 'configures delegated roles' do
+      should contain_keystone_role("role1").with(
+        :ensure  => 'present'
+      )
+      should contain_keystone_role("role2").with(
+        :ensure  => 'present'
+      )
+    end
   end
 
 end

--- a/heat/spec/classes/heat_keystone_domain_spec.rb
+++ b/heat/spec/classes/heat_keystone_domain_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe 'heat::keystone::domain' do
+
+  let :params do {
+    :auth_url          => 'http://127.0.0.1:35357/v2.0',
+    :keystone_admin    => 'admin',
+    :keystone_password => 'admin_passwd',
+    :keystone_tenant   => 'admin',
+    :domain_name       => 'heat',
+    :domain_admin      => 'heat_admin',
+    :domain_password   => 'domain_passwd'
+    }
+  end
+
+  shared_examples_for 'heat keystone domain' do
+    it 'configure heat.conf' do
+      should contain_heat_config('DEFAULT/stack_domain_admin').with_value(params[:domain_admin])
+      should contain_heat_config('DEFAULT/stack_domain_admin_password').with_value(params[:domain_password])
+    end
+
+    it 'should configure heat domain id' do
+      should contain_heat_domain_id_setter('heat_domain_id').with(
+        :ensure           => 'present',
+        :domain_name      => params[:domain_name],
+        :auth_url         => params[:auth_url],
+        :auth_username    => params[:keystone_admin],
+        :auth_password    => params[:keystone_password],
+        :auth_tenant_name => params[:keystone_tenant]
+      )
+    end
+
+    it 'should exec helper script' do
+      should contain_exec('heat_domain_create').with(
+        :command     => 'heat-keystone-setup-domain &>/dev/null',
+        :path        => '/usr/bin',
+        :require     => 'Package[heat-common]',
+        :environment => [
+            "OS_USERNAME=#{params[:keystone_admin]}",
+            "OS_PASSWORD=#{params[:keystone_password]}",
+            "OS_AUTH_URL=#{params[:auth_url]}",
+            "HEAT_DOMAIN=#{params[:domain_name]}",
+            "HEAT_DOMAIN_ADMIN=#{params[:domain_admin]}",
+            "HEAT_DOMAIN_PASSWORD=#{params[:domain_password]}"
+        ]
+      )
+    end
+  end
+
+
+  context 'on Debian platforms' do
+    let :facts do
+      { :osfamily => 'Debian' }
+    end
+
+    it_configures 'heat keystone domain'
+  end
+
+  context 'on RedHat platforms' do
+    let :facts do
+      { :osfamily => 'RedHat' }
+    end
+
+    it_configures 'heat keystone domain'
+  end
+end

--- a/heat/spec/spec_helper.rb
+++ b/heat/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'shared_examples'
+require 'webmock/rspec'
+require 'json'
 
 RSpec.configure do |c|
   c.alias_it_should_behave_like_to :it_configures, 'configures'

--- a/heat/spec/unit/provider/heat_domain_id_setter/heat_spec.rb
+++ b/heat/spec/unit/provider/heat_domain_id_setter/heat_spec.rb
@@ -1,0 +1,177 @@
+require 'spec_helper'
+require 'puppet'
+require 'puppet/type/heat_domain_id_setter'
+
+provider_class = Puppet::Type.type(:heat_domain_id_setter).provider(:ruby)
+
+# used to simulate an authentication response from Keystone
+# (POST v2.0/tokens)
+auth_response = {
+    'access' => {
+        'token' => {
+            'id' => 'TOKEN',
+        }
+    }
+}
+
+# used to simulate a response to GET v3/domains
+domains_response = {
+    'domains' => [
+        {
+            'name' => 'heat',
+            'id'   => 'UUID_HEAT'
+        },
+        {
+            'name' => 'multiple_matches_domain',
+            'id'   => 'UUID1'
+        },
+        {
+            'name' => 'multiple_matches_domain',
+            'id'   => 'UUID2'
+        },
+    ]
+}
+
+# Stub for ini_setting resource
+Puppet::Type.newtype(:ini_setting) do
+end
+
+# Stub for ini_setting provider
+Puppet::Type.newtype(:ini_setting).provide(:ruby) do
+    def create
+    end
+end
+
+describe 'Puppet::Type.type(:heat_keystone_domain_id_setter)' do
+    let :params do
+        {
+            :name             => 'heat_domain_id',
+            :ensure           => 'present',
+            :domain_name      => 'heat',
+            :auth_url         => 'http://127.0.0.1:35357/v2.0',
+            :auth_username    => 'admin',
+            :auth_password    => 'admin_passwd',
+            :auth_tenant_name => 'admin',
+        }
+    end
+
+    it 'should have a non-nil provider' do
+        expect(provider_class).not_to be_nil
+    end
+
+    context 'when url is correct' do
+        before :each do
+            stub_request(:post, "http://127.0.0.1:35357/v2.0/tokens").
+                to_return(:status => 200,
+                          :body => auth_response.to_json,
+                          :headers => {})
+            stub_request(:get, "http://127.0.0.1:35357/v3/domains").
+                with(:headers => {'X-Auth-Token'=>'TOKEN'}).
+                to_return(:status => 200,
+                          :body => domains_response.to_json,
+                          :headers => {})
+        end
+
+        it 'should create a resource' do
+            resource = Puppet::Type::Heat_domain_id_setter.new(params)
+            provider = provider_class.new(resource)
+            expect(provider.exists?).to be_false
+            expect(provider.create).to be_nil
+        end
+    end
+
+    # What happens if we ask for a domain that does not exist?
+    context 'when domain cannot be found' do
+        before :each do
+            stub_request(:post, "http://127.0.0.1:35357/v2.0/tokens").
+                to_return(:status => 200,
+                          :body => auth_response.to_json,
+                          :headers => {})
+            stub_request(:get, "http://127.0.0.1:35357/v3/domains").
+                with(:headers => {'X-Auth-Token'=>'TOKEN'}).
+                to_return(:status => 200,
+                          :body => domains_response.to_json,
+                          :headers => {})
+
+            params.merge!(:domain_name => 'bad_domain_name')
+        end
+
+        it 'should receive an api error' do
+            resource = Puppet::Type::Heat_domain_id_setter.new(params)
+            provider = provider_class.new(resource)
+            expect(provider.exists?).to be_false
+            expect { provider.create }.to raise_error KeystoneAPIError, /Unable to find matching domain/
+        end
+    end
+
+    # What happens if we ask for a domain name that results in multiple
+    # matches?
+    context 'when there are multiple matching domains' do
+        before :each do
+            stub_request(:post, "http://127.0.0.1:35357/v2.0/tokens").
+                to_return(:status => 200,
+                          :body => auth_response.to_json,
+                          :headers => {})
+            stub_request(:get, "http://127.0.0.1:35357/v3/domains").
+                with(:headers => {'X-Auth-Token'=>'TOKEN'}).
+                to_return(:status => 200,
+                          :body => domains_response.to_json,
+                          :headers => {})
+
+            params.merge!(:domain_name => 'multiple_matches_domain')
+        end
+
+        it 'should receive an api error' do
+            resource = Puppet::Type::Heat_domain_id_setter.new(params)
+            provider = provider_class.new(resource)
+            expect(provider.exists?).to be_false
+            expect { provider.create }.to raise_error KeystoneAPIError, /Found multiple matches for domain name/
+        end
+    end
+
+    # What happens if we pass a bad password?
+    context 'when password is incorrect' do
+        before :each do
+            stub_request(:post, "http://127.0.0.1:35357/v2.0/tokens").
+                to_return(:status => 401,
+                          :body => auth_response.to_json,
+                          :headers => {})
+        end
+
+        it 'should receive an authentication error' do
+            resource = Puppet::Type::Heat_domain_id_setter.new(params)
+            provider = provider_class.new(resource)
+            expect(provider.exists?).to be_false
+            expect { provider.create }.to raise_error KeystoneAPIError
+        end
+    end
+
+    # What happens if the server is not listening?
+    context 'when keystone server is unavailable' do
+        before :each do
+            stub_request(:post, "http://127.0.0.1:35357/v2.0/tokens").to_raise Errno::ECONNREFUSED
+        end
+
+        it 'should receive a connection error' do
+            resource = Puppet::Type::Heat_domain_id_setter.new(params)
+            provider = provider_class.new(resource)
+            expect(provider.exists?).to be_false
+            expect { provider.create }.to raise_error KeystoneConnectionError
+        end
+    end
+
+    # What happens if we mistype the hostname?
+    context 'when keystone server is unknown' do
+        before :each do
+            stub_request(:post, "http://127.0.0.1:35357/v2.0/tokens").to_raise SocketError, 'getaddrinfo: Name or service not known'
+        end
+
+        it 'should receive a connection error' do
+            resource = Puppet::Type::Heat_domain_id_setter.new(params)
+            provider = provider_class.new(resource)
+            expect(provider.exists?).to be_false
+            expect { provider.create }.to raise_error KeystoneConnectionError
+        end
+    end
+
+end


### PR DESCRIPTION
This module update commit was generated by Bade.
For more info please check https://github.com/paramite/bade

This commit is setting modules to following state:
heat
 - old commit: 7e90ad8c9d2411e591c511cf516f41a5da184a02
 - new commit: dc4861e396c6c992e1bfc26cd3dc5cf47b3021ce

Signed-off-by: Gael Chamoulaud <gchamoul@redhat.com>

Conflicts:
	Puppetfile
	heat/manifests/keystone/auth.pp