### PR TITLE
Bring puppet-manila up to date

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -71,7 +71,7 @@ mod 'keystone',
   :git => 'https://github.com/stackforge/puppet-keystone.git'
 
 mod 'manila',
-  :commit => 'cbc52b88da4bbb3090d21b3010d309c131ad353e',
+  :commit => '46ba0607b678b3ba76cd5f5245d381f8712201b8',
   :git => 'https://github.com/stackforge/puppet-manila.git'
 
 mod 'memcached',

--- a/manila/.fixtures.yml
+++ b/manila/.fixtures.yml
@@ -1,15 +1,13 @@
 fixtures:
   repositories:
     'apt': 'git://github.com/puppetlabs/puppetlabs-apt.git'
+    'concat': 'git://github.com/puppetlabs/puppetlabs-concat.git'
     'inifile':  'git://github.com/puppetlabs/puppetlabs-inifile'
     'keystone': 'git://github.com/stackforge/puppet-keystone.git'
-    'mysql':
-      repo: 'git://github.com/puppetlabs/puppetlabs-mysql.git'
-      ref:  'origin/2.2.x'
+    'glance': 'git://github.com/stackforge/puppet-glance.git'
+    'mysql': 'git://github.com/puppetlabs/puppetlabs-mysql.git'
     'openstacklib': 'git://github.com/stackforge/puppet-openstacklib.git'
-    'postgresql':
-      repo: 'git://github.com/puppetlabs/puppet-postgresql.git'
-      ref: '2.5.0'
+    'postgresql': 'git://github.com/puppetlabs/puppet-postgresql.git'
     'qpid': 'git://github.com/dprince/puppet-qpid.git'
     'rabbitmq':
       repo: 'git://github.com/puppetlabs/puppetlabs-rabbitmq'

--- a/manila/manifests/backend/generic.pp
+++ b/manila/manifests/backend/generic.pp
@@ -41,7 +41,7 @@
 # [*share_helpers*]
 #   (optional) Specify list of share export helpers.
 #   Defaults to: ['CIFS=manila.share.drivers.generic.CIFSHelper',
-#                'NFS=manila.share.drivers.generic.NFSHelper']
+#                 'NFS=manila.share.drivers.generic.NFSHelper']
 #
 define manila::backend::generic (
   $share_backend_name               = $name,
@@ -70,6 +70,6 @@ define manila::backend::generic (
     "${name}/max_time_to_attach":               value => $max_time_to_attach;
     "${name}/service_instance_smb_config_path": value => $service_instance_smb_config_path;
     "${name}/share_volume_fstype":              value => $share_volume_fstype;
-    "${name}/share_helpers":                    value => $share_helpers;
+    "${name}/share_helpers":                    value => join($share_helpers, ',');
   }
 }

--- a/manila/manifests/db/postgresql.pp
+++ b/manila/manifests/db/postgresql.pp
@@ -1,21 +1,45 @@
+# == Class: manila::db::postgresql
 #
 # Class that configures postgresql for manila
-#
 # Requires the Puppetlabs postgresql module.
+#
+# === Parameters
+#
+# [*password*]
+#   (Required) Password to connect to the database.
+#
+# [*dbname*]
+#   (Optional) Name of the database.
+#   Defaults to 'manila'.
+#
+# [*user*]
+#   (Optional) User to connect to the database.
+#   Defaults to 'manila'.
+#
+#  [*encoding*]
+#    (Optional) The charset to use for the database.
+#    Default to undef.
+#
+#  [*privileges*]
+#    (Optional) Privileges given to the database user.
+#    Default to 'ALL'
+#
 class manila::db::postgresql(
   $password,
-  $dbname = 'manila',
-  $user   = 'manila'
+  $dbname     = 'manila',
+  $user       = 'manila',
+  $encoding   = undef,
+  $privileges = 'ALL',
 ) {
 
-  require postgresql::python
-
-  Postgresql::Db[$dbname]    ~> Exec<| title == 'manila-manage db_sync' |>
-  Package['python-psycopg2'] -> Exec<| title == 'manila-manage db_sync' |>
-
-  postgresql::db { $dbname:
-    user      =>  $user,
-    password  =>  $password,
+  ::openstacklib::db::postgresql { 'manila':
+    password_hash => postgresql_password($user, $password),
+    dbname        => $dbname,
+    user          => $user,
+    encoding      => $encoding,
+    privileges    => $privileges,
   }
+
+  ::Openstacklib::Db::Postgresql['manila']    ~> Exec<| title == 'manila-manage db_sync' |>
 
 }

--- a/manila/manifests/share/generic.pp
+++ b/manila/manifests/share/generic.pp
@@ -38,8 +38,8 @@
 #
 # [*share_helpers*]
 #   (optional) Specify list of share export helpers.
-#   Defaults to: ['CIFS=manila.share.drivers.generic.CIFSHelper',
-#                 'NFS=manila.share.drivers.generic.NFSHelper']
+#   Defaults to:  ['CIFS=manila.share.drivers.generic.CIFSHelper',
+#                  'NFS=manila.share.drivers.generic.NFSHelper']
 #
 
 class manila::share::generic (

--- a/manila/metadata.json
+++ b/manila/metadata.json
@@ -34,6 +34,7 @@
     { "name": "dprince/qpid", "version_requirement": ">=1.0.0 <2.0.0" },
     { "name": "puppetlabs/inifile", "version_requirement": ">=1.0.0 <2.0.0" },
     { "name": "stackforge/keystone", "version_requirement": ">=5.0.0 <6.0.0" },
+    { "name": "stackforge/glance", "version_requirement": ">=6.0.0" },
     { "name": "puppetlabs/rabbitmq", "version_requirement": ">=2.0.2 <4.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.0.0 <5.0.0" },
     { "name": "stackforge/openstacklib", "version_requirement": ">=5.0.0" }

--- a/manila/spec/classes/manila_db_postgresql_spec.rb
+++ b/manila/spec/classes/manila_db_postgresql_spec.rb
@@ -3,24 +3,56 @@ require 'spec_helper'
 describe 'manila::db::postgresql' do
 
   let :req_params do
-    {:password => 'pw'}
+    { :password => 'pw' }
   end
 
-  let :facts do
-    {
-      :postgres_default_version => '8.4',
-      :osfamily => 'RedHat',
-    }
+  let :pre_condition do
+    'include postgresql::server'
   end
 
-  describe 'with only required params' do
-    let :params do
-      req_params
+  context 'on a RedHat osfamily' do
+    let :facts do
+      {
+        :osfamily                 => 'RedHat',
+        :operatingsystemrelease   => '7.0',
+        :concat_basedir => '/var/lib/puppet/concat'
+      }
     end
-    it { should contain_postgresql__db('manila').with(
-      :user         => 'manila',
-      :password     => 'pw'
-     ) }
+
+    context 'with only required parameters' do
+      let :params do
+        req_params
+      end
+
+      it { should contain_postgresql__server__db('manila').with(
+        :user     => 'manila',
+        :password => 'md5b15a47e3dd847f86827b328466426faf'
+      )}
+    end
+
+  end
+
+  context 'on a Debian osfamily' do
+    let :facts do
+      {
+        :operatingsystemrelease => '7.8',
+        :operatingsystem        => 'Debian',
+        :osfamily               => 'Debian',
+        :concat_basedir => '/var/lib/puppet/concat'
+      }
+    end
+
+    context 'with only required parameters' do
+      let :params do
+        req_params
+      end
+
+      it { should contain_postgresql__server__db('manila').with(
+        :user     => 'manila',
+        :password => 'md5b15a47e3dd847f86827b328466426faf'
+      )}
+    end
+
   end
 
 end

--- a/manila/spec/classes/manila_share_generic_spec.rb
+++ b/manila/spec/classes/manila_share_generic_spec.rb
@@ -11,8 +11,6 @@ describe 'manila::share::generic' do
       :max_time_to_create_volume        => 180,
       :max_time_to_attach               => 120,
       :service_instance_smb_config_path => '$share_mount_path/smb.conf',
-      :share_helpers                    => ['CIFS=manila.share.drivers.generic.CIFSHelper',
-                                            'NFS=manila.share.drivers.generic.NFSHelper'],
       :share_volume_fstype              => 'ext4',
     }
   end
@@ -21,6 +19,9 @@ describe 'manila::share::generic' do
     it 'configures generic share driver' do
       should contain_manila_config('DEFAULT/share_driver').with_value(
         'manila.share.drivers.generic.GenericShareDriver')
+      should contain_manila_config('DEFAULT/share_helpers').with_value(
+        'CIFS=manila.share.drivers.generic.CIFSHelper,'\
+        'NFS=manila.share.drivers.generic.NFSHelper')
       params.each_pair do |config,value|
         should contain_manila_config("DEFAULT/#{config}").with_value( value )
       end

--- a/manila/spec/defines/manila_backend_generic_spec.rb
+++ b/manila/spec/defines/manila_backend_generic_spec.rb
@@ -13,8 +13,6 @@ describe 'manila::backend::generic' do
       :max_time_to_create_volume        => 180,
       :max_time_to_attach               => 120,
       :service_instance_smb_config_path => '$share_mount_path/smb.conf',
-      :share_helpers                    => ['CIFS=manila.share.drivers.generic.CIFSHelper',
-                                            'NFS=manila.share.drivers.generic.NFSHelper'],
       :share_volume_fstype              => 'ext4',
     }
   end
@@ -26,6 +24,9 @@ describe 'manila::backend::generic' do
         :value => 'hippo')
       should contain_manila_config('hippo/share_driver').with_value(
         'manila.share.drivers.generic.GenericShareDriver')
+      should contain_manila_config('hippo/share_helpers').with_value(
+	'CIFS=manila.share.drivers.generic.CIFSHelper,'\
+        'NFS=manila.share.drivers.generic.NFSHelper')
       params.each_pair do |config,value|
         should contain_manila_config("hippo/#{config}").with_value( value )
       end

--- a/manila/spec/defines/manila_service_instance_spec.rb
+++ b/manila/spec/defines/manila_service_instance_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'manila::service_instance' do
+
+  let(:title) {'DEFAULT'}
+
+  let :params do
+    {
+      :service_instance_name_template         => 'manila_service_instance_%s',
+      :service_instance_user                  => 'user1',
+      :service_instance_password              => 'pass1',
+      :manila_service_keypair_name            => 'manila-service',
+      :path_to_public_key                     => '~/.ssh/id_rsa.pub',
+      :path_to_private_key                    => '~/.ssh/id_rsa',
+      :max_time_to_build_instance             => 300,
+      :service_instance_security_group        => 'manila-service',
+      :service_instance_flavor_id             => 1,
+      :service_network_name                   => 'manila_service_network',
+      :service_network_cidr                   => '10.254.0.0/16',
+      :service_network_division_mask          => 28,
+      :interface_driver                       => 'manila.network.linux.interface.OVSInterfaceDriver',
+      :connect_share_server_to_tenant_network => false,
+    }
+  end
+
+  context 'with default parameters' do
+    it 'configures service instance' do
+      expect {
+        params.each_pair do |config,value|
+          should contain_manila_config("DEFAULT/#{config}").with_value( value )
+        end
+      }.to raise_error(Puppet::Error, /Missing required parameter service_image_location/)
+    end
+  end
+
+  context 'with service image provided' do
+    let (:req_params) { params.merge!({
+      :service_image_name     => 'manila-service-image',
+      :service_image_location => 'http://example.com/manila_service_image.iso',
+    }) }
+
+    it 'creates Glance image' do
+      should contain_glance_image(req_params[:service_image_name]).with(
+        :ensure           => 'present',
+        :is_public        => 'yes',
+        :container_format => 'bare',
+        :disk_format      => 'qcow2',
+        :source           => req_params[:service_image_location]
+        )
+    end
+  end
+end


### PR DESCRIPTION
Specifically bring in the changes to the service
instance that will enable Packstack to use Manila
correctly.