### PR TITLE
Add fwaas package for Kilo in Red Hat platforms

### DIFF
--- a/neutron/manifests/params.pp
+++ b/neutron/manifests/params.pp
@@ -57,6 +57,8 @@ class neutron::params {
     $l3_agent_package   = false
     $l3_agent_service   = 'neutron-l3-agent'
 
+    $fwaas_package      = 'openstack-neutron-fwaas'
+
     $metadata_agent_service = 'neutron-metadata-agent'
 
     $cliff_package      = 'python-cliff'
@@ -125,6 +127,8 @@ class neutron::params {
 
     $l3_agent_package   = 'neutron-l3-agent'
     $l3_agent_service   = 'neutron-l3-agent'
+
+    $fwaas_package      = false
 
     $cliff_package      = 'python-cliff'
     $kernel_headers     = "linux-headers-${::kernelrelease}"

--- a/neutron/manifests/services/fwaas.pp
+++ b/neutron/manifests/services/fwaas.pp
@@ -59,9 +59,9 @@ class neutron::services::fwaas (
     }
   } elsif($::osfamily == 'Redhat') {
     # RH platforms
-    ensure_resource( 'package', $::neutron::params::package_name,
+    ensure_resource( 'package', $::neutron::params::fwaas_package,
       { 'ensure' => $neutron::package_ensure })
-    Package[$::neutron::params::package_name] -> Neutron_fwaas_service_config<||>
+    Package[$::neutron::params::fwaas_package] -> Neutron_fwaas_service_config<||>
   }
 
   neutron_fwaas_service_config {

--- a/neutron/spec/classes/neutron_services_fwaas_spec.rb
+++ b/neutron/spec/classes/neutron_services_fwaas_spec.rb
@@ -90,11 +90,14 @@ describe 'neutron::services::fwaas' do
     end
 
     let :platform_params do
-      { :package_name => 'openstack-neutron' }
+      { :fwaas_package => 'openstack-neutron-fwaas' }
     end
 
     it_configures 'neutron fwaas service plugin'
 
+    it 'installs neutron fwaas service package' do
+      should contain_package('openstack-neutron-fwaas').with_ensure('present')
+    end
   end
 
 end


### PR DESCRIPTION
Since Kilo, we have a new package for FWaaS: openstack-neutron-fwaas, so the service is no longer part of openstack-neutron.