### PR TITLE
Pacemaker cve bump

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -96,7 +96,7 @@ mod 'openstack',
 
 mod 'pacemaker',
   :commit => '5d91343c80f65b64be604f4a61558ff408c0f863',
-  :git => 'https://github.com/radez/puppet-pacemaker.git'
+  :git => 'https://github.com/redhat-openstack/puppet-pacemaker.git'
 
 mod 'puppet',
   :commit => 'bd467cae15eba9ca44274034d2593b0eaf30518d',

--- a/Puppetfile
+++ b/Puppetfile
@@ -95,7 +95,7 @@ mod 'openstack',
   :git => 'https://github.com/stackforge/puppet-openstack.git'
 
 mod 'pacemaker',
-  :commit => '0ed9ee8a29c0f27e86727d415b39d2715332df7d',
+  :commit => '5d91343c80f65b64be604f4a61558ff408c0f863',
   :git => 'https://github.com/radez/puppet-pacemaker.git'
 
 mod 'puppet',

--- a/pacemaker/manifests/corosync.pp
+++ b/pacemaker/manifests/corosync.pp
@@ -53,13 +53,13 @@ class pacemaker::corosync(
     }
     ->
     exec {"Set password for hacluster user on $cluster_name":
-      command => "/bin/echo ${::pacemaker::params::hacluster_pwd} | /usr/bin/passwd --stdin hacluster",
+      command => "/bin/echo ${::pacemaker::hacluster_pwd} | /usr/bin/passwd --stdin hacluster",
       creates => "/etc/cluster/cluster.conf",
       require => Class["::pacemaker::install"],
     }
     ->
     exec {"auth-successful-across-all-nodes":
-      command => "/usr/sbin/pcs cluster auth $cluster_members -u hacluster -p ${::pacemaker::params::hacluster_pwd} --force",
+      command => "/usr/sbin/pcs cluster auth $cluster_members -u hacluster -p ${::pacemaker::hacluster_pwd} --force",
       timeout   => 3600,
       tries     => 360,
       try_sleep => 10,


### PR DESCRIPTION
This changes are necesary to fix this bug:  
CVE-2015-1842 openstack-puppet-modules: pacemaker configured with default password [openstack-5-rhel7]  (https://bugzilla.redhat.com/show_bug.cgi?id=1206973)
