### PR TITLE
Log Aggregation: Enable Log Aggregation in puppet-tripleo

### DIFF
--- a/galera/manifests/server.pp
+++ b/galera/manifests/server.pp
@@ -85,14 +85,12 @@
 # }
 #
 class galera::server (
-  $mysql_server_hash     = {},
   $bootstrap             = false,
   $debug                 = false,
   $service_name          = 'mariadb',
   $service_enable        = true,
   $service_ensure        = 'running',
   $manage_service        = false,
-  $wsrep_bind_address    = '0.0.0.0',
   $wsrep_node_address    = undef,
   $wsrep_provider        = '/usr/lib64/galera/libgalera_smm.so',
   $wsrep_cluster_name    = 'galera_cluster',
@@ -103,11 +101,23 @@ class galera::server (
   $wsrep_ssl             = false,
   $wsrep_ssl_key         = undef,
   $wsrep_ssl_cert        = undef,
+  $create_mysql_resource = true,
+  # DEPRECATED OPTIONS
+  $mysql_server_hash     = {},
+  $wsrep_bind_address    = '0.0.0.0',
 )  {
 
-  $mysql_server_class = { 'mysql::server' => $mysql_server_hash }
+  if $create_mysql_resource {
+  warning("DEPRECATED: ::mysql::server should be called manually, please set create_mysql_resource to false and call class ::mysql::server with your config")
 
-  create_resources( 'class', $mysql_server_class )
+    $mysql_server_class = { 'mysql::server' => $mysql_server_hash }
+
+    create_resources( 'class', $mysql_server_class )
+  }
+
+  if $wsrep_bind_address {
+    warning("DEPRECATED: wsrep_bind_address is deprecated, you should use bind_address of mysql module")
+  }
 
   $wsrep_provider_options = wsrep_options({
     'socket.ssl'      => $wsrep_ssl,

--- a/horizon/manifests/init.pp
+++ b/horizon/manifests/init.pp
@@ -207,7 +207,7 @@ class horizon(
   $available_regions       = undef,
   $api_result_limit        = 1000,
   $log_level               = 'INFO',
-  $help_url                = 'http://docs.openstack.org',
+  $help_url                = 'http://openstack.redhat.com/Docs',
   $local_settings_template = 'horizon/local_settings.py.erb',
   $configure_apache        = true,
   $bind_address            = undef,

--- a/horizon/manifests/wsgi/apache.pp
+++ b/horizon/manifests/wsgi/apache.pp
@@ -170,8 +170,8 @@ class horizon::wsgi::apache (
     error_log_file              => 'horizon_error.log',
     priority                    => $priority,
     aliases                     => [{
-      alias => '/static',
-      path => '/usr/share/openstack-dashboard/static',
+      alias => "${$::horizon::params::root_url}/static",
+      path  => '/usr/share/openstack-dashboard/static',
     }],
     port                        => 80,
     ssl_cert                    => $horizon_cert,

--- a/horizon/spec/classes/horizon_init_spec.rb
+++ b/horizon/spec/classes/horizon_init_spec.rb
@@ -97,7 +97,7 @@ describe 'horizon' do
           :neutron_options         => {'enable_lb' => true, 'enable_firewall' => true, 'enable_quotas' => false, 'enable_security_group' => false, 'enable_vpn' => true,
                                        'enable_distributed_router' => false, 'enable_ha_router' => false, 'profile_support' => 'cisco', },
           :file_upload_temp_dir    => '/var/spool/horizon',
-          :secure_cookies          => true
+          :secure_cookies          => true,
         })
       end
 
@@ -299,6 +299,12 @@ describe 'horizon' do
     end
 
     it_behaves_like 'horizon'
+
+    it 'sets WEBROOT in local_settings.py' do
+      verify_concat_fragment_contents(catalogue, 'local_settings.py', [
+        "WEBROOT = '/dashboard/'",
+      ])
+    end
   end
 
   context 'on Debian platforms' do
@@ -316,5 +322,11 @@ describe 'horizon' do
     end
 
     it_behaves_like 'horizon'
+
+    it 'sets WEBROOT in local_settings.py' do
+      verify_concat_fragment_contents(catalogue, 'local_settings.py', [
+        "WEBROOT = '/horizon/'",
+      ])
+    end
   end
 end

--- a/horizon/spec/classes/horizon_wsgi_apache_spec.rb
+++ b/horizon/spec/classes/horizon_wsgi_apache_spec.rb
@@ -203,6 +203,11 @@ describe 'horizon::wsgi::apache' do
     it {
       is_expected.to contain_class('apache::mod::wsgi').with(:wsgi_socket_prefix => '/var/run/wsgi')
     }
+    it 'configures webroot alias' do
+      is_expected.to contain_apache__vhost('horizon_vhost').with(
+        'aliases' => [['alias', '/dashboard/static'], ['path', '/usr/share/openstack-dashboard/static']],
+      )
+    end
   end
 
   context 'on Debian platforms' do
@@ -226,5 +231,10 @@ describe 'horizon::wsgi::apache' do
     end
 
     it_behaves_like 'apache for horizon'
+    it 'configures webroot alias' do
+      is_expected.to contain_apache__vhost('horizon_vhost').with(
+        'aliases' => [['alias', '/horizon/static'], ['path', '/usr/share/openstack-dashboard/static']],
+      )
+    end
   end
 end

--- a/horizon/templates/local_settings.py.erb
+++ b/horizon/templates/local_settings.py.erb
@@ -7,6 +7,10 @@ from openstack_dashboard import exceptions
 DEBUG = <%= @django_debug.to_s.capitalize %>
 TEMPLATE_DEBUG = DEBUG
 
+# WEBROOT is the location relative to Webserver root
+# should end with a slash.
+WEBROOT = '<%= scope.lookupvar("horizon::params::root_url") %>/'
+
 # Required for Django 1.5.
 # If horizon is running in production (DEBUG is False), set this
 # with the list of host/domain names that the application can serve.

--- a/keystone/spec/classes/keystone_spec.rb
+++ b/keystone/spec/classes/keystone_spec.rb
@@ -277,6 +277,21 @@ describe 'keystone' do
     ) }
   end
 
+  describe 'with disabled service managing' do
+    let :params do
+      { :admin_token    => 'service_token',
+        :manage_service => false,
+        :enabled        => false }
+    end
+
+    it { is_expected.to contain_service('keystone').with(
+      'ensure'     => nil,
+      'enable'     => false,
+      'hasstatus'  => true,
+      'hasrestart' => true
+    ) }
+  end
+
   describe 'when configuring signing token provider' do
 
     describe 'when configuring as UUID' do

--- a/manifests/log_aggregation_source.pp
+++ b/manifests/log_aggregation_source.pp
@@ -1,0 +1,74 @@
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# == Define: tripleo::log_aggregation_source
+#
+# Capture logs from an OpenStack service using Fluentd
+#
+# === Parameters:
+#
+# [*path*]
+#  (String) the path to the log file to tail
+#
+# [*multiline*]
+#  (bool) whether or not to capture multiline log output as a single line
+#  Defaults to true
+#
+
+define tripleo::log_aggregation_source ( $path, $multiline = true ) {
+  $log_format = '/(?<time>[^ ]* [^ ]*) (?<pid>[^ ]*) (?<loglevel>[^ ]*) (?<class>[^ ]*) \[(?<context>.*)\] (?<message>.*)/'
+  $log_format_firstline = '/(?<time>[^ ]* [^ ]*) (?<pid>[^ ]*) (?<loglevel>[^ ]*) (?<class>[^ ]*) \[(?<context>.*)\] (?<message>.*)/'
+  $time_format = '%F %T.%L'
+
+  if $multiline {
+    # NB(sross): puppet-fluentd can't represent multiple keys with the
+    # same name, so we have "format" and " format"
+    # (i.e. the space is important)
+    fluentd::source { "input-${name}":
+      config => {
+        '@type'            => 'tail',
+        'path'             => $path,
+        'tag'              => $name,
+        ' format'          => 'multiline',
+        'format_firstline' => $log_format_firstline,
+        'format'           => $log_format,
+        'time_format'      => $time_format
+      },
+      notify => Class['fluentd::service']
+    }
+  } else {
+    fluentd::source { "input-${name}":
+      config => {
+        '@type'       => 'tail',
+        'path'        => $path,
+        'tag'         => $name,
+        'format'      => $log_format,
+        'time_format' => $time_format
+      },
+      notify => Class['fluentd::service']
+    }
+  }
+
+  # puppet-fluentd doesn't have a good way to represent nested
+  # structures (for the '<pair>' # element).
+  fluentd::match { "add-metadata-to-${name}":
+    pattern => $name,
+    config  => {
+      '@type'  => 'add',
+      '<pair>' => "\n  service ${name}\n  hostname \"#{Socket.gethostname}\"\n</pair>"
+    },
+    notify  => Class['fluentd::service']
+  }
+}

--- a/neutron/lib/puppet/provider/neutron_agent_ovs/ini_setting.rb
+++ b/neutron/lib/puppet/provider/neutron_agent_ovs/ini_setting.rb
@@ -1,0 +1,26 @@
+Puppet::Type.type(:neutron_agent_ovs).provide(
+  :ini_setting,
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+
+  def section
+    resource[:name].split('/', 2).first
+  end
+
+  def setting
+    resource[:name].split('/', 2).last
+  end
+
+  def separator
+    '='
+  end
+
+  def file_path
+    if Facter['osfamily'].value == 'Debian'
+      '/etc/neutron/plugins/ml2/ml2_conf.ini'
+    else
+      '/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini'
+    end
+  end
+
+end

--- a/neutron/lib/puppet/provider/neutron_network/neutron.rb
+++ b/neutron/lib/puppet/provider/neutron_network/neutron.rb
@@ -80,8 +80,10 @@ Puppet::Type.type(:neutron_network).provide(
         "--provider:segmentation_id=#{@resource[:provider_segmentation_id]}"
     end
 
-    if @resource[:router_external]
-      network_opts << "--router:external=#{@resource[:router_external]}"
+    if @resource[:router_external] == 'False'
+      network_opts << '--router:external=False'
+    else
+      network_opts << '--router:external'
     end
 
     results = auth_neutron('net-create', '--format=shell',
@@ -120,7 +122,11 @@ Puppet::Type.type(:neutron_network).provide(
   end
 
   def router_external=(value)
-    auth_neutron('net-update', "--router:external=#{value}", name)
+    if value == 'False'
+      auth_neutron('net-update', "--router:external=#{value}", name)
+    else
+      auth_neutron('net-update', "--router:external", name)
+    end
   end
 
   [

--- a/neutron/lib/puppet/type/neutron_agent_ovs.rb
+++ b/neutron/lib/puppet/type/neutron_agent_ovs.rb
@@ -1,0 +1,18 @@
+Puppet::Type.newtype(:neutron_agent_ovs) do
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'Section/setting name to manage from ovs agent config.'
+    newvalues(/\S+\/\S+/)
+  end
+
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |value|
+      value = value.to_s.strip
+      value.capitalize! if value =~ /^(true|false)$/i
+      value
+    end
+  end
+end

--- a/neutron/manifests/agents/ml2/ovs.pp
+++ b/neutron/manifests/agents/ml2/ovs.pp
@@ -232,7 +232,6 @@ class neutron::agents::ml2::ovs (
   if $::neutron::params::ovs_cleanup_service {
     Package['neutron-ovs-agent'] -> Service['ovs-cleanup-service']
     service { 'ovs-cleanup-service':
-      ensure => $service_ensure,
       name   => $::neutron::params::ovs_cleanup_service,
       enable => $enabled,
     }

--- a/neutron/manifests/agents/ml2/ovs.pp
+++ b/neutron/manifests/agents/ml2/ovs.pp
@@ -117,7 +117,8 @@ class neutron::agents::ml2::ovs (
     fail('L2 population must be enabled when DVR is enabled')
   }
 
-  Neutron_plugin_ml2<||> ~> Service['neutron-ovs-agent-service']
+  Package['neutron-ovs-agent'] -> Neutron_agent_ovs<||>
+  Neutron_agent_ovs<||> ~> Service['neutron-ovs-agent-service']
 
   if ($bridge_mappings != []) {
     # bridge_mappings are used to describe external networks that are
@@ -135,7 +136,7 @@ class neutron::agents::ml2::ovs (
     # Set config for bridges that we're going to create
     # The OVS neutron plugin will talk in terms of the networks in the bridge_mappings
     $br_map_str = join($bridge_mappings, ',')
-    neutron_plugin_ml2 {
+    neutron_agent_ovs {
       'ovs/bridge_mappings': value => $br_map_str;
     }
     neutron::plugins::ovs::bridge{ $bridge_mappings:
@@ -146,7 +147,7 @@ class neutron::agents::ml2::ovs (
     }
   }
 
-  neutron_plugin_ml2 {
+  neutron_agent_ovs {
     'agent/polling_interval':           value => $polling_interval;
     'agent/l2_population':              value => $l2_population;
     'agent/arp_responder':              value => $arp_responder;
@@ -154,12 +155,10 @@ class neutron::agents::ml2::ovs (
     'ovs/integration_bridge':           value => $integration_bridge;
   }
 
-  if ($firewall_driver) {
-    neutron_plugin_ml2 { 'securitygroup/firewall_driver':
-      value => $firewall_driver
-    }
+  if $firewall_driver {
+    neutron_agent_ovs { 'securitygroup/firewall_driver': value => $firewall_driver }
   } else {
-    neutron_plugin_ml2 { 'securitygroup/firewall_driver': ensure => absent }
+    neutron_agent_ovs { 'securitygroup/firewall_driver': ensure => absent }
   }
 
   vs_bridge { $integration_bridge:
@@ -172,25 +171,25 @@ class neutron::agents::ml2::ovs (
       ensure => present,
       before => Service['neutron-ovs-agent-service'],
     }
-    neutron_plugin_ml2 {
+    neutron_agent_ovs {
       'ovs/enable_tunneling': value => true;
       'ovs/tunnel_bridge':    value => $tunnel_bridge;
       'ovs/local_ip':         value => $local_ip;
     }
 
     if size($tunnel_types) > 0 {
-      neutron_plugin_ml2 {
+      neutron_agent_ovs {
         'agent/tunnel_types': value => join($tunnel_types, ',');
       }
     }
     if 'vxlan' in $tunnel_types {
       validate_vxlan_udp_port($vxlan_udp_port)
-      neutron_plugin_ml2 {
+      neutron_agent_ovs {
         'agent/vxlan_udp_port': value => $vxlan_udp_port;
       }
     }
   } else {
-    neutron_plugin_ml2 {
+    neutron_agent_ovs {
       'ovs/enable_tunneling': value  => false;
       'ovs/tunnel_bridge':    ensure => absent;
       'ovs/local_ip':         ensure => absent;
@@ -199,7 +198,6 @@ class neutron::agents::ml2::ovs (
 
 
   if $::neutron::params::ovs_agent_package {
-    Package['neutron-ovs-agent'] -> Neutron_plugin_ml2<||>
     package { 'neutron-ovs-agent':
       ensure => $package_ensure,
       name   => $::neutron::params::ovs_agent_package,
@@ -209,22 +207,12 @@ class neutron::agents::ml2::ovs (
     # Some platforms (RedHat) do not provide a separate
     # neutron plugin ovs agent package. The configuration file for
     # the ovs agent is provided by the neutron ovs plugin package.
-    Package['neutron-ovs-agent'] -> Neutron_plugin_ml2<||>
-    Package['neutron-ovs-agent'] -> Service['ovs-cleanup-service']
-
     if ! defined(Package['neutron-ovs-agent']) {
       package { 'neutron-ovs-agent':
         ensure => $package_ensure,
         name   => $::neutron::params::ovs_server_package,
         tag    => 'openstack',
-      } ->
-      # https://bugzilla.redhat.com/show_bug.cgi?id=1087647
-      # Causes init script for agent to load the old ovs file
-      # instead of the ml2 config file.
-      file { '/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini':
-        ensure => link,
-        target => '/etc/neutron/plugins/ml2/ml2_conf.ini'
-      } ~> Service<| title == 'neutron-ovs-agent-service' |>
+      }
     }
   }
 
@@ -242,7 +230,8 @@ class neutron::agents::ml2::ovs (
   }
 
   if $::neutron::params::ovs_cleanup_service {
-    service {'ovs-cleanup-service':
+    Package['neutron-ovs-agent'] -> Service['ovs-cleanup-service']
+    service { 'ovs-cleanup-service':
       ensure => $service_ensure,
       name   => $::neutron::params::ovs_cleanup_service,
       enable => $enabled,

--- a/neutron/spec/classes/neutron_agents_ml2_ovs_spec.rb
+++ b/neutron/spec/classes/neutron_agents_ml2_ovs_spec.rb
@@ -34,15 +34,15 @@ describe 'neutron::agents::ml2::ovs' do
     it { is_expected.to contain_class('neutron::params') }
 
     it 'configures ovs_neutron_plugin.ini' do
-      is_expected.to contain_neutron_plugin_ml2('agent/polling_interval').with_value(p[:polling_interval])
-      is_expected.to contain_neutron_plugin_ml2('agent/l2_population').with_value(p[:l2_population])
-      is_expected.to contain_neutron_plugin_ml2('agent/arp_responder').with_value(p[:arp_responder])
-      is_expected.to contain_neutron_plugin_ml2('ovs/integration_bridge').with_value(p[:integration_bridge])
-      is_expected.to contain_neutron_plugin_ml2('securitygroup/firewall_driver').\
+      is_expected.to contain_neutron_agent_ovs('agent/polling_interval').with_value(p[:polling_interval])
+      is_expected.to contain_neutron_agent_ovs('agent/l2_population').with_value(p[:l2_population])
+      is_expected.to contain_neutron_agent_ovs('agent/arp_responder').with_value(p[:arp_responder])
+      is_expected.to contain_neutron_agent_ovs('ovs/integration_bridge').with_value(p[:integration_bridge])
+      is_expected.to contain_neutron_agent_ovs('securitygroup/firewall_driver').\
         with_value(p[:firewall_driver])
-      is_expected.to contain_neutron_plugin_ml2('ovs/enable_tunneling').with_value(false)
-      is_expected.to contain_neutron_plugin_ml2('ovs/tunnel_bridge').with_ensure('absent')
-      is_expected.to contain_neutron_plugin_ml2('ovs/local_ip').with_ensure('absent')
+      is_expected.to contain_neutron_agent_ovs('ovs/enable_tunneling').with_value(false)
+      is_expected.to contain_neutron_agent_ovs('ovs/tunnel_bridge').with_ensure('absent')
+      is_expected.to contain_neutron_agent_ovs('ovs/local_ip').with_ensure('absent')
     end
 
     it 'configures vs_bridge' do
@@ -60,7 +60,7 @@ describe 'neutron::agents::ml2::ovs' do
           :ensure => p[:package_ensure],
           :tag    => 'openstack'
         )
-        is_expected.to contain_package('neutron-ovs-agent').with_before(/Neutron_plugin_ml2\[.+\]/)
+        is_expected.to contain_package('neutron-ovs-agent').with_before(/Neutron_agent_ovs\[.+\]/)
       else
       end
     end
@@ -79,7 +79,7 @@ describe 'neutron::agents::ml2::ovs' do
         params.merge!(:firewall_driver => false)
       end
       it 'should configure firewall driver' do
-        is_expected.to contain_neutron_plugin_ml2('securitygroup/firewall_driver').with_ensure('absent')
+        is_expected.to contain_neutron_agent_ovs('securitygroup/firewall_driver').with_ensure('absent')
       end
     end
 
@@ -88,7 +88,7 @@ describe 'neutron::agents::ml2::ovs' do
         params.merge!(:arp_responder => true)
       end
       it 'should enable ARP responder' do
-        is_expected.to contain_neutron_plugin_ml2('agent/arp_responder').with_value(true)
+        is_expected.to contain_neutron_agent_ovs('agent/arp_responder').with_value(true)
       end
     end
 
@@ -98,7 +98,7 @@ describe 'neutron::agents::ml2::ovs' do
                       :l2_population              => true )
       end
       it 'should enable DVR' do
-        is_expected.to contain_neutron_plugin_ml2('agent/enable_distributed_routing').with_value(true)
+        is_expected.to contain_neutron_agent_ovs('agent/enable_distributed_routing').with_value(true)
       end
     end
 
@@ -108,7 +108,7 @@ describe 'neutron::agents::ml2::ovs' do
       end
 
       it 'configures bridge mappings' do
-        is_expected.to contain_neutron_plugin_ml2('ovs/bridge_mappings')
+        is_expected.to contain_neutron_agent_ovs('ovs/bridge_mappings')
       end
 
       it 'should configure bridge mappings' do
@@ -137,9 +137,9 @@ describe 'neutron::agents::ml2::ovs' do
           params.merge!(:enable_tunneling => true, :local_ip => '127.0.0.1' )
         end
         it 'should configure ovs for tunneling' do
-          is_expected.to contain_neutron_plugin_ml2('ovs/enable_tunneling').with_value(true)
-          is_expected.to contain_neutron_plugin_ml2('ovs/tunnel_bridge').with_value(default_params[:tunnel_bridge])
-          is_expected.to contain_neutron_plugin_ml2('ovs/local_ip').with_value('127.0.0.1')
+          is_expected.to contain_neutron_agent_ovs('ovs/enable_tunneling').with_value(true)
+          is_expected.to contain_neutron_agent_ovs('ovs/tunnel_bridge').with_value(default_params[:tunnel_bridge])
+          is_expected.to contain_neutron_agent_ovs('ovs/local_ip').with_value('127.0.0.1')
           is_expected.to contain_vs_bridge(default_params[:tunnel_bridge]).with(
             :ensure  => 'present',
             :before => 'Service[neutron-ovs-agent-service]'
@@ -156,8 +156,8 @@ describe 'neutron::agents::ml2::ovs' do
         end
 
         it 'should perform vxlan network configuration' do
-          is_expected.to contain_neutron_plugin_ml2('agent/tunnel_types').with_value(params[:tunnel_types])
-          is_expected.to contain_neutron_plugin_ml2('agent/vxlan_udp_port').with_value(params[:vxlan_udp_port])
+          is_expected.to contain_neutron_agent_ovs('agent/tunnel_types').with_value(params[:tunnel_types])
+          is_expected.to contain_neutron_agent_ovs('agent/vxlan_udp_port').with_value(params[:vxlan_udp_port])
         end
       end
 
@@ -204,13 +204,6 @@ describe 'neutron::agents::ml2::ovs' do
         :ensure  => 'running'
       )
       is_expected.to contain_package('neutron-ovs-agent').with_before(/Service\[ovs-cleanup-service\]/)
-    end
-
-    it 'links from ovs config to plugin config' do
-      is_expected.to contain_file('/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini').with(
-        :ensure => 'link',
-        :target => '/etc/neutron/plugins/ml2/ml2_conf.ini'
-      )
     end
   end
 end

--- a/neutron/spec/classes/neutron_agents_ml2_ovs_spec.rb
+++ b/neutron/spec/classes/neutron_agents_ml2_ovs_spec.rb
@@ -200,8 +200,7 @@ describe 'neutron::agents::ml2::ovs' do
     it 'configures neutron ovs cleanup service' do
       is_expected.to contain_service('ovs-cleanup-service').with(
         :name    => platform_params[:ovs_cleanup_service],
-        :enable  => true,
-        :ensure  => 'running'
+        :enable  => true
       )
       is_expected.to contain_package('neutron-ovs-agent').with_before(/Service\[ovs-cleanup-service\]/)
     end

--- a/neutron/spec/unit/provider/neutron_network/neutron_spec.rb
+++ b/neutron/spec/unit/provider/neutron_network/neutron_spec.rb
@@ -46,7 +46,14 @@ describe provider_class do
 
     it 'should call net-update to change router_external' do
       provider.expects(:auth_neutron).with('net-update',
-                                           '--router:external=True',
+                                           '--router:external=False',
+                                           net_name)
+      provider.router_external=('False')
+    end
+
+    it 'should call net-update to change router_external' do
+      provider.expects(:auth_neutron).with('net-update',
+                                           '--router:external',
                                            net_name)
       provider.router_external=('True')
     end

--- a/trove/manifests/api.pp
+++ b/trove/manifests/api.pp
@@ -269,39 +269,60 @@ class trove::api(
   }
 
   if $::trove::rpc_backend == 'trove.openstack.common.rpc.impl_kombu' {
-    # I may want to support exporting and collecting these
+    if ! $::trove::rabbit_password {
+      fail('When rpc_backend is rabbitmq, you must set rabbit password')
+    }
+    if $::trove::rabbit_hosts {
+      trove_config { 'oslo_messaging_rabbit/rabbit_hosts':     value  => join($::trove::rabbit_hosts, ',') }
+      trove_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value  => true }
+    } else  {
+      trove_config { 'oslo_messaging_rabbit/rabbit_host':      value => $::trove::rabbit_host }
+      trove_config { 'oslo_messaging_rabbit/rabbit_port':      value => $::trove::rabbit_port }
+      trove_config { 'oslo_messaging_rabbit/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}" }
+      trove_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value => false }
+    }
+
     trove_config {
-      'DEFAULT/rabbit_password':     value => $::trove::rabbit_password, secret => true;
-      'DEFAULT/rabbit_userid':       value => $::trove::rabbit_userid;
-      'DEFAULT/rabbit_virtual_host': value => $::trove::rabbit_virtual_host;
-      'DEFAULT/rabbit_use_ssl':      value => $::trove::rabbit_use_ssl;
-      'DEFAULT/amqp_durable_queues': value => $::trove::amqp_durable_queues;
+      'oslo_messaging_rabbit/rabbit_userid':         value => $::trove::rabbit_user;
+      'oslo_messaging_rabbit/rabbit_password':       value => $::trove::rabbit_password, secret => true;
+      'oslo_messaging_rabbit/rabbit_virtual_host':   value => $::trove::rabbit_virtual_host;
+      'oslo_messaging_rabbit/rabbit_use_ssl':        value => $::trove::rabbit_use_ssl;
+      'oslo_messaging_rabbit/kombu_reconnect_delay': value => $::trove::kombu_reconnect_delay;
     }
 
     if $::trove::rabbit_use_ssl {
-      trove_config {
-        'DEFAULT/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs;
-        'DEFAULT/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
-        'DEFAULT/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
-        'DEFAULT/kombu_ssl_version':  value => $::trove::kombu_ssl_version;
-      }
-    } else {
-      trove_config {
-        'DEFAULT/kombu_ssl_ca_certs': ensure => absent;
-        'DEFAULT/kombu_ssl_certfile': ensure => absent;
-        'DEFAULT/kombu_ssl_keyfile':  ensure => absent;
-        'DEFAULT/kombu_ssl_version':  ensure => absent;
-      }
-    }
 
-    if $::trove::rabbit_hosts {
-      trove_config { 'DEFAULT/rabbit_hosts':     value => join($::trove::rabbit_hosts, ',') }
-      trove_config { 'DEFAULT/rabbit_ha_queues': value => true }
+      if $::trove::kombu_ssl_ca_certs {
+        trove_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs; }
+      } else {
+        trove_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent; }
+      }
+
+      if $::trove::kombu_ssl_certfile or $::trove::kombu_ssl_keyfile {
+        trove_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
+        }
+      } else {
+        trove_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        }
+      }
+
+      if $::trove::kombu_ssl_version {
+        trove_config { 'oslo_messaging_rabbit/kombu_ssl_version':  value => $::trove::kombu_ssl_version; }
+      } else {
+        trove_config { 'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent; }
+      }
+
     } else {
-      trove_config { 'DEFAULT/rabbit_host':      value => $::trove::rabbit_host }
-      trove_config { 'DEFAULT/rabbit_port':      value => $::trove::rabbit_port }
-      trove_config { 'DEFAULT/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}" }
-      trove_config { 'DEFAULT/rabbit_ha_queues': value => false }
+      trove_config {
+        'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent;
+      }
     }
   }
 

--- a/trove/manifests/conductor.pp
+++ b/trove/manifests/conductor.pp
@@ -99,40 +99,60 @@ class trove::conductor(
   }
 
   if $::trove::rpc_backend == 'trove.openstack.common.rpc.impl_kombu' {
-    # I may want to support exporting and collecting these
+    if ! $::trove::rabbit_password {
+      fail('When rpc_backend is rabbitmq, you must set rabbit password')
+    }
+    if $::trove::rabbit_hosts {
+      trove_conductor_config { 'oslo_messaging_rabbit/rabbit_hosts':     value  => join($::trove::rabbit_hosts, ',') }
+      trove_conductor_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value  => true }
+    } else  {
+      trove_conductor_config { 'oslo_messaging_rabbit/rabbit_host':      value => $::trove::rabbit_host }
+      trove_conductor_config { 'oslo_messaging_rabbit/rabbit_port':      value => $::trove::rabbit_port }
+      trove_conductor_config { 'oslo_messaging_rabbit/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}" }
+      trove_conductor_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value => false }
+    }
+
     trove_conductor_config {
-      'DEFAULT/rabbit_password':           value => $::trove::rabbit_password, secret => true;
-      'DEFAULT/rabbit_userid':             value => $::trove::rabbit_userid;
-      'DEFAULT/rabbit_virtual_host':       value => $::trove::rabbit_virtual_host;
-      'DEFAULT/rabbit_use_ssl':            value => $::trove::rabbit_use_ssl;
-      'DEFAULT/amqp_durable_queues':       value => $::trove::amqp_durable_queues;
-      'DEFAULT/rabbit_notification_topic': value => $::trove::rabbit_notification_topic;
+      'oslo_messaging_rabbit/rabbit_userid':         value => $::trove::rabbit_user;
+      'oslo_messaging_rabbit/rabbit_password':       value => $::trove::rabbit_password, secret => true;
+      'oslo_messaging_rabbit/rabbit_virtual_host':   value => $::trove::rabbit_virtual_host;
+      'oslo_messaging_rabbit/rabbit_use_ssl':        value => $::trove::rabbit_use_ssl;
+      'oslo_messaging_rabbit/kombu_reconnect_delay': value => $::trove::kombu_reconnect_delay;
     }
 
     if $::trove::rabbit_use_ssl {
-      trove_conductor_config {
-        'DEFAULT/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs;
-        'DEFAULT/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
-        'DEFAULT/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
-        'DEFAULT/kombu_ssl_version':  value => $::trove::kombu_ssl_version;
-      }
-    } else {
-      trove_conductor_config {
-        'DEFAULT/kombu_ssl_ca_certs': ensure => absent;
-        'DEFAULT/kombu_ssl_certfile': ensure => absent;
-        'DEFAULT/kombu_ssl_keyfile':  ensure => absent;
-        'DEFAULT/kombu_ssl_version':  ensure => absent;
-      }
-    }
 
-    if $::trove::rabbit_hosts {
-      trove_conductor_config { 'DEFAULT/rabbit_hosts':     value => join($::trove::rabbit_hosts, ',') }
-      trove_conductor_config { 'DEFAULT/rabbit_ha_queues': value => true }
+      if $::trove::kombu_ssl_ca_certs {
+        trove_conductor_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs; }
+      } else {
+        trove_conductor_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent; }
+      }
+
+      if $::trove::kombu_ssl_certfile or $::trove::kombu_ssl_keyfile {
+        trove_conductor_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
+        }
+      } else {
+        trove_conductor_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        }
+      }
+
+      if $::trove::kombu_ssl_version {
+        trove_conductor_config { 'oslo_messaging_rabbit/kombu_ssl_version':  value => $::trove::kombu_ssl_version; }
+      } else {
+        trove_conductor_config { 'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent; }
+      }
+
     } else {
-      trove_conductor_config { 'DEFAULT/rabbit_host':      value => $::trove::rabbit_host }
-      trove_conductor_config { 'DEFAULT/rabbit_port':      value => $::trove::rabbit_port }
-      trove_conductor_config { 'DEFAULT/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}" }
-      trove_conductor_config { 'DEFAULT/rabbit_ha_queues': value => false }
+      trove_conductor_config {
+        'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent;
+      }
     }
   }
 

--- a/trove/manifests/guestagent.pp
+++ b/trove/manifests/guestagent.pp
@@ -88,43 +88,59 @@ class trove::guestagent(
   }
 
   if $::trove::rpc_backend == 'trove.openstack.common.rpc.impl_kombu' {
-    # I may want to support exporting and collecting these
+      if ! $::trove::rabbit_password {
+      fail('When rpc_backend is rabbitmq, you must set rabbit password')
+    }
+    if $::trove::rabbit_hosts {
+      trove_guestagent_config { 'oslo_messaging_rabbit/rabbit_hosts':     value  => join($::trove::rabbit_hosts, ',') }
+      trove_guestagent_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value  => true }
+    } else  {
+      trove_guestagent_config { 'oslo_messaging_rabbit/rabbit_host':      value => $::trove::rabbit_host }
+      trove_guestagent_config { 'oslo_messaging_rabbit/rabbit_port':      value => $::trove::rabbit_port }
+      trove_guestagent_config { 'oslo_messaging_rabbit/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}" }
+      trove_guestagent_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value => false }
+    }
+
     trove_guestagent_config {
-      'DEFAULT/rabbit_password':           value => $::trove::rabbit_password, secret => true;
-      'DEFAULT/rabbit_userid':             value => $::trove::rabbit_userid;
-      'DEFAULT/rabbit_virtual_host':       value => $::trove::rabbit_virtual_host;
-      'DEFAULT/rabbit_use_ssl':            value => $::trove::rabbit_use_ssl;
-      'DEFAULT/amqp_durable_queues':       value => $::trove::amqp_durable_queues;
-      'DEFAULT/rabbit_notification_topic': value => $::trove::rabbit_notification_topic;
+      'oslo_messaging_rabbit/rabbit_userid':         value => $::trove::rabbit_user;
+      'oslo_messaging_rabbit/rabbit_password':       value => $::trove::rabbit_password, secret => true;
+      'oslo_messaging_rabbit/rabbit_virtual_host':   value => $::trove::rabbit_virtual_host;
+      'oslo_messaging_rabbit/rabbit_use_ssl':        value => $::trove::rabbit_use_ssl;
+      'oslo_messaging_rabbit/kombu_reconnect_delay': value => $::trove::kombu_reconnect_delay;
     }
 
     if $::trove::rabbit_use_ssl {
-      trove_guestagent_config {
-        'DEFAULT/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs;
-        'DEFAULT/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
-        'DEFAULT/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
-        'DEFAULT/kombu_ssl_version':  value => $::trove::kombu_ssl_version;
-      }
-    } else {
-      trove_guestagent_config {
-        'DEFAULT/kombu_ssl_ca_certs': ensure => absent;
-        'DEFAULT/kombu_ssl_certfile': ensure => absent;
-        'DEFAULT/kombu_ssl_keyfile':  ensure => absent;
-        'DEFAULT/kombu_ssl_version':  ensure => absent;
-      }
-    }
 
-    if $::trove::rabbit_hosts {
-      trove_guestagent_config {
-        'DEFAULT/rabbit_hosts':     value => join($::trove::rabbit_hosts, ',');
-        'DEFAULT/rabbit_ha_queues': value => true
+      if $::trove::kombu_ssl_ca_certs {
+        trove_guestagent_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs; }
+      } else {
+        trove_guestagent_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent; }
       }
+
+      if $::trove::kombu_ssl_certfile or $::trove::kombu_ssl_keyfile {
+        trove_guestagent_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
+        }
+      } else {
+        trove_guestagent_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        }
+      }
+
+      if $::trove::kombu_ssl_version {
+        trove_guestagent_config { 'oslo_messaging_rabbit/kombu_ssl_version':  value => $::trove::kombu_ssl_version; }
+      } else {
+        trove_guestagent_config { 'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent; }
+      }
+
     } else {
       trove_guestagent_config {
-        'DEFAULT/rabbit_host':      value => $::trove::rabbit_host;
-        'DEFAULT/rabbit_port':      value => $::trove::rabbit_port;
-        'DEFAULT/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}";
-        'DEFAULT/rabbit_ha_queues': value => false
+        'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent;
       }
     }
   }

--- a/trove/manifests/init.pp
+++ b/trove/manifests/init.pp
@@ -143,6 +143,9 @@
 # [*control_exchange*]
 #   (optional) Control exchange.
 #   Defaults to 'trove'.
+# [*use_neutron*]
+#   (optional) Use Neutron
+#   Defaults to true
 #
 # [*cinder_url*]
 #   (optional) URL without the tenant segment.
@@ -183,6 +186,7 @@ class trove(
   $use_neutron                  = true,
   # DEPRECATED PARAMETERS
   $mysql_module                 = undef,
+  $use_neutron                  = true,
 ) {
   include ::trove::params
 

--- a/trove/manifests/init.pp
+++ b/trove/manifests/init.pp
@@ -69,7 +69,7 @@
 #   (optional) SSL version to use (valid only if SSL enabled).
 #   Valid values are TLSv1, SSLv23 and SSLv3. SSLv2 may be
 #   available on some distributions.
-#   Defaults to 'SSLv3'
+#   Defaults to 'TLSv1'
 #
 # [*amqp_durable_queues*]
 #   (optional) Define queues as "durable" to rabbitmq.
@@ -172,7 +172,7 @@ class trove(
   $kombu_ssl_ca_certs           = undef,
   $kombu_ssl_certfile           = undef,
   $kombu_ssl_keyfile            = undef,
-  $kombu_ssl_version            = 'SSLv3',
+  $kombu_ssl_version            = 'TLSv1',
   $amqp_durable_queues          = false,
   $database_connection          = 'sqlite:////var/lib/trove/trove.sqlite',
   $database_idle_timeout        = 3600,

--- a/trove/manifests/taskmanager.pp
+++ b/trove/manifests/taskmanager.pp
@@ -120,39 +120,60 @@ class trove::taskmanager(
   }
 
   if $::trove::rpc_backend == 'trove.openstack.common.rpc.impl_kombu' {
-    # I may want to support exporting and collecting these
+    if ! $::trove::rabbit_password {
+      fail('When rpc_backend is rabbitmq, you must set rabbit password')
+    }
+    if $::trove::rabbit_hosts {
+      trove_taskmanager_config { 'oslo_messaging_rabbit/rabbit_hosts':     value  => join($::trove::rabbit_hosts, ',') }
+      trove_taskmanager_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value  => true }
+    } else  {
+      trove_taskmanager_config { 'oslo_messaging_rabbit/rabbit_host':      value => $::trove::rabbit_host }
+      trove_taskmanager_config { 'oslo_messaging_rabbit/rabbit_port':      value => $::trove::rabbit_port }
+      trove_taskmanager_config { 'oslo_messaging_rabbit/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}" }
+      trove_taskmanager_config { 'oslo_messaging_rabbit/rabbit_ha_queues': value => false }
+    }
+
     trove_taskmanager_config {
-      'DEFAULT/rabbit_password':     value => $::trove::rabbit_password, secret => true;
-      'DEFAULT/rabbit_userid':       value => $::trove::rabbit_userid;
-      'DEFAULT/rabbit_virtual_host': value => $::trove::rabbit_virtual_host;
-      'DEFAULT/rabbit_use_ssl':      value => $::trove::rabbit_use_ssl;
-      'DEFAULT/amqp_durable_queues': value => $::trove::amqp_durable_queues;
+      'oslo_messaging_rabbit/rabbit_userid':         value => $::trove::rabbit_user;
+      'oslo_messaging_rabbit/rabbit_password':       value => $::trove::rabbit_password, secret => true;
+      'oslo_messaging_rabbit/rabbit_virtual_host':   value => $::trove::rabbit_virtual_host;
+      'oslo_messaging_rabbit/rabbit_use_ssl':        value => $::trove::rabbit_use_ssl;
+      'oslo_messaging_rabbit/kombu_reconnect_delay': value => $::trove::kombu_reconnect_delay;
     }
 
     if $::trove::rabbit_use_ssl {
-      trove_taskmanager_config {
-        'DEFAULT/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs;
-        'DEFAULT/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
-        'DEFAULT/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
-        'DEFAULT/kombu_ssl_version':  value => $::trove::kombu_ssl_version;
-      }
-    } else {
-      trove_taskmanager_config {
-        'DEFAULT/kombu_ssl_ca_certs': ensure => absent;
-        'DEFAULT/kombu_ssl_certfile': ensure => absent;
-        'DEFAULT/kombu_ssl_keyfile':  ensure => absent;
-        'DEFAULT/kombu_ssl_version':  ensure => absent;
-      }
-    }
 
-    if $::trove::rabbit_hosts {
-      trove_taskmanager_config { 'DEFAULT/rabbit_hosts':     value => join($::trove::rabbit_hosts, ',') }
-      trove_taskmanager_config { 'DEFAULT/rabbit_ha_queues': value => true }
+      if $::trove::kombu_ssl_ca_certs {
+        trove_taskmanager_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': value => $::trove::kombu_ssl_ca_certs; }
+      } else {
+        trove_taskmanager_config { 'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent; }
+      }
+
+      if $::trove::kombu_ssl_certfile or $::trove::kombu_ssl_keyfile {
+        trove_taskmanager_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': value => $::trove::kombu_ssl_certfile;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  value => $::trove::kombu_ssl_keyfile;
+        }
+      } else {
+        trove_taskmanager_config {
+          'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+          'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        }
+      }
+
+      if $::trove::kombu_ssl_version {
+        trove_taskmanager_config { 'oslo_messaging_rabbit/kombu_ssl_version':  value => $::trove::kombu_ssl_version; }
+      } else {
+        trove_taskmanager_config { 'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent; }
+      }
+
     } else {
-      trove_taskmanager_config { 'DEFAULT/rabbit_host':      value => $::trove::rabbit_host }
-      trove_taskmanager_config { 'DEFAULT/rabbit_port':      value => $::trove::rabbit_port }
-      trove_taskmanager_config { 'DEFAULT/rabbit_hosts':     value => "${::trove::rabbit_host}:${::trove::rabbit_port}" }
-      trove_taskmanager_config { 'DEFAULT/rabbit_ha_queues': value => false }
+      trove_taskmanager_config {
+        'oslo_messaging_rabbit/kombu_ssl_ca_certs': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_certfile': ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_keyfile':  ensure => absent;
+        'oslo_messaging_rabbit/kombu_ssl_version':  ensure => absent;
+      }
     }
   }
 

--- a/trove/spec/classes/trove_api_spec.rb
+++ b/trove/spec/classes/trove_api_spec.rb
@@ -81,7 +81,7 @@ describe 'trove::api' do
              rabbit_host           => '10.0.0.1'}"
         end
         it 'configures trove-api with RabbitMQ' do
-          is_expected.to contain_trove_config('DEFAULT/rabbit_host').with_value('10.0.0.1')
+          is_expected.to contain_trove_config('oslo_messaging_rabbit/rabbit_host').with_value('10.0.0.1')
         end
       end
 
@@ -92,7 +92,7 @@ describe 'trove::api' do
              rabbit_hosts          => ['10.0.0.1','10.0.0.2']}"
         end
         it 'configures trove-api with RabbitMQ' do
-          is_expected.to contain_trove_config('DEFAULT/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
+          is_expected.to contain_trove_config('oslo_messaging_rabbit/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
         end
       end
 
@@ -107,6 +107,60 @@ describe 'trove::api' do
         end
       end
     end
+
+    context 'with SSL enabled with kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true,
+           kombu_ssl_ca_certs => '/path/to/ssl/ca/certs',
+           kombu_ssl_certfile => '/path/to/ssl/cert/file',
+           kombu_ssl_keyfile  => '/path/to/ssl/keyfile',
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_value('/path/to/ssl/ca/certs')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_value('/path/to/ssl/cert/file')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_value('/path/to/ssl/keyfile')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL enabled without kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true}"
+      end
+
+      it do
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL disabled' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => false,
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('false')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_config('oslo_messaging_rabbit/kombu_ssl_version').with_ensure('absent')
+      end
+    end
+
   end
 
   context 'on Debian platforms' do

--- a/trove/spec/classes/trove_conductor_spec.rb
+++ b/trove/spec/classes/trove_conductor_spec.rb
@@ -40,7 +40,7 @@ describe 'trove::conductor' do
              rabbit_host           => '10.0.0.1'}"
         end
         it 'configures trove-conductor with RabbitMQ' do
-          is_expected.to contain_trove_conductor_config('DEFAULT/rabbit_host').with_value('10.0.0.1')
+          is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/rabbit_host').with_value('10.0.0.1')
         end
       end
 
@@ -51,7 +51,7 @@ describe 'trove::conductor' do
              rabbit_hosts          => ['10.0.0.1','10.0.0.2']}"
         end
         it 'configures trove-conductor with RabbitMQ' do
-          is_expected.to contain_trove_conductor_config('DEFAULT/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
+          is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
         end
       end
 
@@ -66,6 +66,60 @@ describe 'trove::conductor' do
         end
       end
     end
+
+    context 'with SSL enabled with kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true,
+           kombu_ssl_ca_certs => '/path/to/ssl/ca/certs',
+           kombu_ssl_certfile => '/path/to/ssl/cert/file',
+           kombu_ssl_keyfile  => '/path/to/ssl/keyfile',
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_value('/path/to/ssl/ca/certs')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_value('/path/to/ssl/cert/file')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_value('/path/to/ssl/keyfile')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL enabled without kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true}"
+      end
+
+      it do
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL disabled' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => false,
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('false')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_conductor_config('oslo_messaging_rabbit/kombu_ssl_version').with_ensure('absent')
+      end
+    end
+
   end
 
   context 'on Debian platforms' do

--- a/trove/spec/classes/trove_guestagent_spec.rb
+++ b/trove/spec/classes/trove_guestagent_spec.rb
@@ -40,7 +40,7 @@ describe 'trove::guestagent' do
              rabbit_host           => '10.0.0.1'}"
         end
         it 'configures trove-guestagent with RabbitMQ' do
-          is_expected.to contain_trove_guestagent_config('DEFAULT/rabbit_host').with_value('10.0.0.1')
+          is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/rabbit_host').with_value('10.0.0.1')
         end
       end
 
@@ -51,7 +51,7 @@ describe 'trove::guestagent' do
              rabbit_hosts          => ['10.0.0.1','10.0.0.2']}"
         end
         it 'configures trove-guestagent with RabbitMQ' do
-          is_expected.to contain_trove_guestagent_config('DEFAULT/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
+          is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
         end
       end
     end
@@ -69,6 +69,59 @@ describe 'trove::guestagent' do
       it 'configures trove-guestagent with custom parameters' do
         is_expected.to contain_trove_guestagent_config('DEFAULT/trove_auth_url').with_value('http://10.0.0.1:5000/v2.0')
         is_expected.to contain_trove_guestagent_config('DEFAULT/swift_url').with_value('http://10.0.0.1:8080/v1/AUTH_')
+      end
+    end
+
+    context 'with SSL enabled with kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true,
+           kombu_ssl_ca_certs => '/path/to/ssl/ca/certs',
+           kombu_ssl_certfile => '/path/to/ssl/cert/file',
+           kombu_ssl_keyfile  => '/path/to/ssl/keyfile',
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_value('/path/to/ssl/ca/certs')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_value('/path/to/ssl/cert/file')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_value('/path/to/ssl/keyfile')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL enabled without kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true}"
+      end
+
+      it do
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL disabled' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => false,
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('false')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_guestagent_config('oslo_messaging_rabbit/kombu_ssl_version').with_ensure('absent')
       end
     end
 

--- a/trove/spec/classes/trove_taskmanager_spec.rb
+++ b/trove/spec/classes/trove_taskmanager_spec.rb
@@ -59,7 +59,7 @@ describe 'trove::taskmanager' do
              rabbit_host           => '10.0.0.1'}"
         end
         it 'configures trove-taskmanager with RabbitMQ' do
-          is_expected.to contain_trove_taskmanager_config('DEFAULT/rabbit_host').with_value('10.0.0.1')
+          is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/rabbit_host').with_value('10.0.0.1')
         end
       end
 
@@ -70,7 +70,7 @@ describe 'trove::taskmanager' do
              rabbit_hosts          => ['10.0.0.1','10.0.0.2']}"
         end
         it 'configures trove-taskmanager with RabbitMQ' do
-          is_expected.to contain_trove_taskmanager_config('DEFAULT/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
+          is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/rabbit_hosts').with_value(['10.0.0.1,10.0.0.2'])
         end
       end
 
@@ -125,6 +125,59 @@ describe 'trove::taskmanager' do
         end
       end
     end
+    context 'with SSL enabled with kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true,
+           kombu_ssl_ca_certs => '/path/to/ssl/ca/certs',
+           kombu_ssl_certfile => '/path/to/ssl/cert/file',
+           kombu_ssl_keyfile  => '/path/to/ssl/keyfile',
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_value('/path/to/ssl/ca/certs')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_value('/path/to/ssl/cert/file')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_value('/path/to/ssl/keyfile')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL enabled without kombu' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => true}"
+      end
+
+      it do
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('true')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_version').with_value('TLSv1')
+      end
+    end
+
+    context 'with SSL disabled' do
+      let :pre_condition do
+        "class { 'trove':
+           nova_proxy_admin_pass => 'verysecrete',
+           rabbit_use_ssl     => false,
+           kombu_ssl_version  => 'TLSv1'}"
+      end
+
+      it do
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/rabbit_use_ssl').with_value('false')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_ca_certs').with_ensure('absent')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_certfile').with_ensure('absent')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_keyfile').with_ensure('absent')
+        is_expected.to contain_trove_taskmanager_config('oslo_messaging_rabbit/kombu_ssl_version').with_ensure('absent')
+      end
+    end
+
   end
 
   context 'on Debian platforms' do


### PR DESCRIPTION
This resource is intended to help with setting up log aggregation.
It defines a fluentd source which tails the give source path,
and adds some metadata to resulting log entries.

Depends-On: Ib739de0ca70b8f85c0b4fb3c9ea57fd9c2b0fa61
Change-Id: I87524bc81621d7a1c4a1ab8f7c6ac049b1443371